### PR TITLE
Remove fake-ansible from Galaxy import workflow

### DIFF
--- a/.github/workflows/import-galaxy.yml
+++ b/.github/workflows/import-galaxy.yml
@@ -70,9 +70,6 @@ jobs:
       - name: Install ansible-core
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
-      - name: Install fake-ansible
-        run: pip install https://github.com/felixfontein/fake-ansible/archive/main.tar.gz --disable-pip-version-check
-
       - name: Install galaxy-importer
         run: pip install galaxy-importer --disable-pip-version-check
 


### PR DESCRIPTION
##### SUMMARY
galaxy-importer no longer depends on ansible, but on ansible-core: https://github.com/ansible/galaxy-importer/commit/98933547831922c45243f39d85eefe150b55fc36

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
GHA import-galaxy workflow
