### PR TITLE
Use semantic markup

### DIFF
--- a/docs/docsite/rst/filter_guide.rst
+++ b/docs/docsite/rst/filter_guide.rst
@@ -45,23 +45,23 @@ The filters also allow additional options (keyword arguments):
 
 :keep_unknown_suffix:
 
-  A boolean with default value ``true``. This treats unknown TLDs as valid public suffixes. So for example the public suffix of ``example.tlddoesnotexist`` is ``.tlddoesnotexist`` if this is ``true``. If set to ``false``, it will return an empty string in this case. This option corresponds to whether the global wildcard rule ``*`` in the Public Suffix List is used or not.
+  A boolean with default value :ansval:`true`. This treats unknown TLDs as valid public suffixes. So for example the public suffix of :ansval:`example.tlddoesnotexist` is ``.tlddoesnotexist`` if this is :ansval:`true`. If set to :ansval:`false`, it will return an empty string in this case. This option corresponds to whether the global wildcard rule ``*`` in the Public Suffix List is used or not.
 
 :icann_only:
 
-  A boolean with default value ``false``. This controls whether only entries from the ICANN section of the Public Suffix List are used, or also entries from the Private section. For example, ``.co.uk`` is in the ICANN section, but ``github.io`` is in the Private section.
+  A boolean with default value :ansval:`false`. This controls whether only entries from the ICANN section of the Public Suffix List are used, or also entries from the Private section. For example, ``.co.uk`` is in the ICANN section, but ``github.io`` is in the Private section.
 
 :normalize_result:
 
-  (Only for :ref:`community.dns.get_public_suffix <ansible_collections.community.dns.get_public_suffix_filter>`) A boolean with default value ``false``. This controls whether the result is reconstructed from the normalized name used during lookup. During normalization, ulabels are converted to alabels, and every label is converted to lowercase. For example, the ulabel ``ëçãmplê`` is converted to ``xn--mpl-llatwb`` (puny-code), and ``Example.COM`` is converted to ``example.com``.
+  (Only for :ref:`community.dns.get_public_suffix <ansible_collections.community.dns.get_public_suffix_filter>`) A boolean with default value :ansval:`false`. This controls whether the result is reconstructed from the normalized name used during lookup. During normalization, ulabels are converted to alabels, and every label is converted to lowercase. For example, the ulabel :ansval:`ëçãmplê` is converted to ``xn--mpl-llatwb`` (puny-code), and :ansval:`Example.COM` is converted to ``example.com``.
 
 :keep_leading_period:
 
-  (Only for :ref:`community.dns.get_public_suffix <ansible_collections.community.dns.get_public_suffix_filter>`) A boolean with default value ``true``. This controls whether the leading period of a public suffix is preserved or not.
+  (Only for :ref:`community.dns.get_public_suffix <ansible_collections.community.dns.get_public_suffix_filter>`) A boolean with default value :ansval:`true`. This controls whether the leading period of a public suffix is preserved or not.
 
 :keep_trailing_period:
 
-  (Only for :ref:`community.dns.remove_public_suffix <ansible_collections.community.dns.remove_public_suffix_filter>`) A boolean with default value ``false``. This controls whether the trailing period of the prefix (that is, the part before the public suffix) is preserved or not.
+  (Only for :ref:`community.dns.remove_public_suffix <ansible_collections.community.dns.remove_public_suffix_filter>`) A boolean with default value :ansval:`false`. This controls whether the trailing period of the prefix (that is, the part before the public suffix) is preserved or not.
 
 Working with registrable domain names
 -------------------------------------
@@ -85,20 +85,20 @@ The filters also allow additional options (keyword arguments):
 
 :keep_unknown_suffix:
 
-  A boolean with default value ``true``. This treats unknown TLDs as valid public suffixes. So for example the public suffix of ``example.tlddoesnotexist`` is ``.tlddoesnotexist`` if this is ``true``, and hence the registrable domain of ``www.example.tlddoesnotexist`` is ``example.tlddoesnotexist``. If set to ``false``, the registrable domain of ``www.example.tlddoesnotexist`` is ``tlddoesnotexist``. This option corresponds to whether the global wildcard rule ``*`` in the Public Suffix List is used or not.
+  A boolean with default value :ansval:`true`. This treats unknown TLDs as valid public suffixes. So for example the public suffix of :ansval:`example.tlddoesnotexist` is ``.tlddoesnotexist`` if this is :ansval:`true`, and hence the registrable domain of :ansval:`www.example.tlddoesnotexist` is ``example.tlddoesnotexist``. If set to :ansval:`false`, the registrable domain of :ansval:`www.example.tlddoesnotexist` is ``tlddoesnotexist``. This option corresponds to whether the global wildcard rule ``*`` in the Public Suffix List is used or not.
 
 :icann_only:
 
-  A boolean with default value ``false``. This controls whether only entries from the ICANN section of the Public Suffix List are used, or also entries from the Private section. For example, ``.co.uk`` is in the ICANN section, but ``github.io`` is in the Private section.
+  A boolean with default value :ansval:`false`. This controls whether only entries from the ICANN section of the Public Suffix List are used, or also entries from the Private section. For example, ``.co.uk`` is in the ICANN section, but ``github.io`` is in the Private section.
 
 :only_if_registerable:
 
-  A boolean with default value ``true``. This controls the behavior in case there is no label in front of the public suffix. This is the case if the DNS name itself is a public suffix. If set to ``false``, in this case the public suffix is treated as a registrable domain. If set to ``true`` (default), the registrable domain of a public suffix is interpreted as an empty string.
+  A boolean with default value :ansval:`true`. This controls the behavior in case there is no label in front of the public suffix. This is the case if the DNS name itself is a public suffix. If set to :ansval:`false`, in this case the public suffix is treated as a registrable domain. If set to :ansval:`true` (default), the registrable domain of a public suffix is interpreted as an empty string.
 
 :normalize_result:
 
-  (Only for :ref:`community.dns.get_registrable_domain <ansible_collections.community.dns.get_registrable_domain_filter>`) A boolean with default value ``false``. This controls whether the result is reconstructed from the normalized name used during lookup. During normalization, ulabels are converted to alabels, and every label is converted to lowercase. For example, the ulabel ``ëçãmplê`` is converted to ``xn--mpl-llatwb`` (puny-code), and ``Example.COM`` is converted to ``example.com``.
+  (Only for :ref:`community.dns.get_registrable_domain <ansible_collections.community.dns.get_registrable_domain_filter>`) A boolean with default value :ansval:`false`. This controls whether the result is reconstructed from the normalized name used during lookup. During normalization, ulabels are converted to alabels, and every label is converted to lowercase. For example, the ulabel :ansval:`ëçãmplê` is converted to ``xn--mpl-llatwb`` (puny-code), and :ansval:`Example.COM` is converted to ``example.com``.
 
 :keep_trailing_period:
 
-  (Only for :ref:`community.dns.remove_registrable_domain <ansible_collections.community.dns.remove_registrable_domain_filter>`) A boolean with default value ``false``. This controls whether the trailing period of the prefix (that is, the part before the registrable domain) is preserved or not.
+  (Only for :ref:`community.dns.remove_registrable_domain <ansible_collections.community.dns.remove_registrable_domain_filter>`) A boolean with default value :ansval:`false`. This controls whether the trailing period of the prefix (that is, the part before the registrable domain) is preserved or not.

--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -33,7 +33,7 @@ It also provides an inventory plugin:
 Authentication
 --------------
 
-To use Hetzner's API, you need to create an API token. You can manage API tokens in the "API tokens" menu entry in your user menu in the `DNS Console <https://dns.hetzner.com/>`_. You must provide the token to the ``hetzner_token`` option of the modules, its alias ``api_token``, or pass it on in the ``HETZNER_DNS_TOKEN`` environment variable:
+To use Hetzner's API, you need to create an API token. You can manage API tokens in the "API tokens" menu entry in your user menu in the `DNS Console <https://dns.hetzner.com/>`_. You must provide the token to the :ansopt:`hetzner_token` option of the modules, its alias :ansopt:`api_token`, or pass it on in the :envvar:`HETZNER_DNS_TOKEN` environment variable:
 
 .. code-block:: yaml+jinja
 
@@ -105,7 +105,7 @@ Working with DNS records
 
 .. note::
 
-  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the ``txt_transformation`` option which allows to configure this behavior.
+  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the :ansopt:`community.dns.hetzner_dns_record_set#module:txt_transformation` option which allows to configure this behavior.
 
 Querying DNS records and record sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -137,7 +137,7 @@ The :ref:`community.dns.hetzner_dns_record_set_info module <ansible_collections.
         msg: There is no A record for www.example.com
       when: not result.set
 
-In all examples in this section, you can replace ``zone_name=example.com`` by ``zone_id=aBcDeFgHiJlMnOpQrStUvW`` with the zone's ID string.
+In all examples in this section, you can replace :ansopt:`community.dns.hetzner_dns_record_set_info#module:zone_name=example.com` by :ansopt:`community.dns.hetzner_dns_record_set_info#module:zone_id=aBcDeFgHiJlMnOpQrStUvW` with the zone's ID string.
 
 You can also query a list of all record sets for a record name or prefix:
 
@@ -200,7 +200,7 @@ The :ref:`community.dns.hetzner_dns_record module <ansible_collections.community
         value: 1.1.1.1
         ttl: 300
 
-To delete records, simply use ``state=absent``. Records will be matched by record name and type, and the TTL will be ignored:
+To delete records, simply use :ansopt:`community.dns.hetzner_dns_record#module:state=absent`. Records will be matched by record name and type, and the TTL will be ignored:
 
 .. code-block:: yaml+jinja
 
@@ -234,9 +234,9 @@ The :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.commu
           - 1.1.1.1
           - 8.8.8.8
 
-If you want to assert that a record has a certain value, set ``on_existing=keep``. Using ``keep_and_warn`` instead will emit a warning if this happens, and ``keep_and_fail`` will make the module fail.
+If you want to assert that a record has a certain value, set :ansopt:`community.dns.hetzner_dns_record_set#module:on_existing=keep`. Using :ansval:`keep_and_warn` instead will emit a warning if this happens, and :ansval:`keep_and_fail` will make the module fail.
 
-To delete values, you can either overwrite the values with value ``[]``, or use ``state=absent``:
+To delete values, you can either overwrite the values with value :ansval:`[]`, or use :ansopt:`community.dns.hetzner_dns_record_set#module:state=absent`:
 
 .. code-block:: yaml+jinja
 
@@ -266,7 +266,7 @@ To delete values, you can either overwrite the values with value ``[]``, or use 
         value:
           - '::1'
 
-In the third example, ``on_existing=keep_and_fail`` is present and an explicit value and TTL are given. This makes the module remove the current value only if there's a AAAA record for ``www.example.com`` whose current value is ``::1`` and whose TTL is 300. If another value is set, the module will not make any change, but fail. This can be useful to not accidentally remove values you do not want to change. To issue a warning instead of failing, use ``on_existing=keep_and_warn``, and to simply not do a change without any indication of this situation, use ``on_existing=keep``.
+In the third example, :ansopt:`community.dns.hetzner_dns_record_set#module:on_existing=keep_and_fail` is present and an explicit value and TTL are given. This makes the module remove the current value only if there's a AAAA record for ``www.example.com`` whose current value is ``::1`` and whose TTL is 300. If another value is set, the module will not make any change, but fail. This can be useful to not accidentally remove values you do not want to change. To issue a warning instead of failing, use :ansopt:`community.dns.hetzner_dns_record_set#module:on_existing=keep_and_warn`, and to simply not do a change without any indication of this situation, use :ansopt:`community.dns.hetzner_dns_record_set#module:on_existing=keep`.
 
 Bulk synchronization of DNS record sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -280,7 +280,7 @@ The following example shows up to set/update multiple records at once:
     - name: Make sure that multiple records are present
       community.dns.hetzner_dns_record_sets:
         zone_name: example.com
-        records:
+        record_sets:
           - prefix: www
             type: A
             value:
@@ -291,7 +291,7 @@ The following example shows up to set/update multiple records at once:
             value:
               - '::1'
 
-The next example shows how to make sure that only the given records are available and all other records are deleted. Note that for the ``type=NS`` record we used ``ignore=true``, which allows us to skip the value. It tells the module that it should not touch the ``NS`` record for ``example.com``.
+The next example shows how to make sure that only the given records are available and all other records are deleted. Note that for the :ansopt:`community.dns.hetzner_dns_record_sets#module:record_sets[].type=NS` record we used :ansopt:`community.dns.hetzner_dns_record_sets#module:record_sets[].ignore=true`, which allows us to skip the value. It tells the module that it should not touch the ``NS`` record for ``example.com``.
 
 .. code-block:: yaml+jinja
 
@@ -299,7 +299,7 @@ The next example shows how to make sure that only the given records are availabl
       community.dns.hetzner_dns_record_sets:
         zone_name: example.com
         prune: true
-        records:
+        record_sets:
           - prefix: www
             type: A
             value:
@@ -330,14 +330,14 @@ The `markuman.hetzner_dns collection <https://galaxy.ansible.com/markuman/hetzne
 
 .. note::
 
-  When working with TXT records, please look at the ``txt_transformation`` option. By default, the modules and plugins in this collection use **unquoted** values (you do not have to add double quotes and escape double quotes and backslashes), while the modules and plugins in ``markuman.hetzner_dns`` use partially quoted values. You can switch behavior of the ``community.dns`` modules by passing ``txt_transformation=api`` or ``txt_transformation=quoted``.
+  When working with TXT records, please look at the :ansopt:`community.dns.hetzner_dns_record_set#module:txt_transformation` option. By default, the modules and plugins in this collection use **unquoted** values (you do not have to add double quotes and escape double quotes and backslashes), while the modules and plugins in ``markuman.hetzner_dns`` use partially quoted values. You can switch behavior of the ``community.dns`` modules by passing :ansopt:`community.dns.hetzner_dns_record_set#module:txt_transformation=api` or :ansopt:`community.dns.hetzner_dns_record_set#module:txt_transformation=quoted`.
 
 The markuman.hetzner_dns.record module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``markuman.hetzner_dns.zone_info`` module can be replaced by the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` and the :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.community.dns.hetzner_dns_record_set_module>`, depending on what it is used for.
 
-When creating, updating or removing single records, the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` should be used. This is the case when ``purge=false`` is specified (the default value). Note that ``replace``, ``overwrite`` and ``solo`` are aliases of ``purge``.
+When creating, updating or removing single records, the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` should be used. This is the case when :ansopt:`purge=false` is specified (the default value). Note that :ansopt:`replace`, :ansopt:`overwrite` and :ansopt:`solo` are aliases of :ansopt:`purge`.
 
 .. code-block:: yaml+jinja
 
@@ -410,7 +410,7 @@ When the ``markuman.hetzner_dns.record`` module is in replace mode, it should be
         # or keep the following option:
         txt_transformation: api
 
-When deleting a record, it depends on whether ``value`` is specified or not. If ``value`` is specified, the module is deleting a single DNS record, and the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` should be used:
+When deleting a record, it depends on whether :ansopt:`value` is specified or not. If :ansopt:`value` is specified, the module is deleting a single DNS record, and the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` should be used:
 
 .. code-block:: yaml+jinja
 
@@ -440,7 +440,7 @@ When deleting a record, it depends on whether ``value`` is specified or not. If 
         # or keep the following option:
         txt_transformation: api
 
-When ``value`` is not specified, the ``markuman.hetzner_dns.record`` module will delete all records for this prefix and type. In that case, it operates on a record set and the :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.community.dns.hetzner_dns_record_set_module>` should be used:
+When :ansopt:`value` is not specified, the ``markuman.hetzner_dns.record`` module will delete all records for this prefix and type. In that case, it operates on a record set and the :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.community.dns.hetzner_dns_record_set_module>` should be used:
 
 .. code-block:: yaml+jinja
 
@@ -463,20 +463,20 @@ When ``value`` is not specified, the ``markuman.hetzner_dns.record`` module will
         # 'type' does not change:
         type: A
 
-A last step is replacing the deprecated alias ``name`` of ``prefix`` by ``prefix``. This can be done later though, if you do not mind the deprecation warnings.
+A last step is replacing the deprecated alias :ansopt:`community.dns.hetzner_dns_record_set#module:name` of :ansopt:`community.dns.hetzner_dns_record_set#module:prefix` by :ansopt:`community.dns.hetzner_dns_record_set#module:prefix`. This can be done later though, if you do not mind the deprecation warnings.
 
 The markuman.hetzner_dns.record_info module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``markuman.hetzner_dns.record_info`` module can be replaced by the :ref:`community.dns.hetzner_dns_record_info module <ansible_collections.community.dns.hetzner_dns_record_info_module>`. The main difference is that instead of by the ``filters`` option, the output is controlled by the ``what`` option (choices ``single_record``, ``all_types_for_record``, and ``all_records``), the ``type`` option (needed when ``what=single_record``), and the ``record`` and ``prefix`` options (needed when ``what`` is not ``all_records``).
+The ``markuman.hetzner_dns.record_info`` module can be replaced by the :ref:`community.dns.hetzner_dns_record_info module <ansible_collections.community.dns.hetzner_dns_record_info_module>`. The main difference is that instead of by the :ansopt:`filters` option, the output is controlled by the :ansopt:`community.dns.hetzner_dns_record_info#module:what` option (choices :ansval:`single_record`, :ansval:`all_types_for_record`, and :ansval:`all_records`), the :ansopt:`community.dns.hetzner_dns_record_info#module:type` option (needed when :ansopt:`community.dns.hetzner_dns_record_info#module:what=single_record`), and the :ansopt:`community.dns.hetzner_dns_record_info#module:record` and :ansopt:`community.dns.hetzner_dns_record_info#module:prefix` options (needed when :ansopt:`community.dns.hetzner_dns_record_info#module:what` is not :ansval:`all_records`).
 
 The markuman.hetzner_dns.zone_info module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``markuman.hetzner_dns.zone_info`` module can be replaced by the :ref:`community.dns.hetzner_dns_zone_info module <ansible_collections.community.dns.hetzner_dns_zone_info_module>`. The main differences are:
 
-1. The parameter ``name`` must be changed to ``zone_name`` or ``zone``.
-2. The return value ``zone_info`` no longer has the ``name`` and ``id`` entries. Use the return values ``zone_name`` and ``zone_id`` instead.
+1. The parameter :ansopt:`name` must be changed to :ansopt:`community.dns.hetzner_dns_zone_info#module:zone_name` or :ansopt:`community.dns.hetzner_dns_zone_info#module:zone`.
+2. The return value :ansretval:`community.dns.hetzner_dns_zone_info#module:zone_info` no longer has the ``name`` and ``id`` entries. Use the return values :ansretval:`community.dns.hetzner_dns_zone_info#module:zone_name` and :ansretval:`community.dns.hetzner_dns_zone_info#module:zone_id` instead.
 
 The markuman.hetzner_dns.inventory inventory plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/docsite/rst/hosttech_guide.rst
+++ b/docs/docsite/rst/hosttech_guide.rst
@@ -36,7 +36,7 @@ HostTech currently has two APIs for working with DNS records: the old WSDL-based
 JSON REST API
 ~~~~~~~~~~~~~
 
-To use the JSON REST API, you need to create a API token. You can manage API tokens in the "DNS Editor" in the "API" section. You must provide the token to the ``hosttech_token`` option of the modules:
+To use the JSON REST API, you need to create a API token. You can manage API tokens in the "DNS Editor" in the "API" section. You must provide the token to the :ansopt:`hosttech_token` option of the modules:
 
 .. code-block:: yaml+jinja
 
@@ -49,7 +49,7 @@ In the examples in this guide, we will leave the authentication options away. Pl
 WSDL API
 ~~~~~~~~
 
-To use the WSDL API, you need to set API credentials. These can be found and changed in the "Servercenter" and there in the "Solutions" section under settings for the "DNS Tool". The username is fixed, but the password can be changed. The credentials must be provided to the ``hosttech_username`` and ``hosttech_password`` options of the modules.
+To use the WSDL API, you need to set API credentials. These can be found and changed in the "Servercenter" and there in the "Solutions" section under settings for the "DNS Tool". The username is fixed, but the password can be changed. The credentials must be provided to the :ansopt:`hosttech_username` and :ansopt:`hosttech_password` options of the modules.
 
 You also need to install the `lxml Python module <https://pypi.org/project/lxml/>`_ to work with the WSDL API. This can be done before using the modules:
 
@@ -129,7 +129,7 @@ Working with DNS records
 
 .. note::
 
-  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the ``txt_transformation`` option which allows to configure this behavior.
+  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the :ansopt:`community.dns.hosttech_dns_record_set#module:txt_transformation` option which allows to configure this behavior.
 
 Querying DNS records and record sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -161,7 +161,7 @@ The :ref:`community.dns.hosttech_dns_record_set_info module <ansible_collections
         msg: There is no A record for www.example.com
       when: not result.set
 
-In all examples in this section, you can replace ``zone_name: example.com`` by ``zone_id: 42`` with the zone's integer ID.
+In all examples in this section, you can replace :ansopt:`community.dns.hosttech_dns_record_set_info#module:zone_name=example.com` by :ansopt:`community.dns.hosttech_dns_record_set_info#module:zone_id=42` with the zone's integer ID.
 
 You can also query a list of all record sets for a record name or prefix:
 
@@ -224,7 +224,7 @@ The :ref:`community.dns.hosttech_dns_record module <ansible_collections.communit
         value: 1.1.1.1
         ttl: 300
 
-To delete records, simply use ``state: absent``. Records will be matched by record name and type, and the TTL will be ignored:
+To delete records, simply use :ansopt:`community.dns.hosttech_dns_record#module:state=absent`. Records will be matched by record name and type, and the TTL will be ignored:
 
 .. code-block:: yaml+jinja
 
@@ -258,9 +258,9 @@ The :ref:`community.dns.hosttech_dns_record_set module <ansible_collections.comm
           - 1.1.1.1
           - 8.8.8.8
 
-If you want to assert that a record has a certain value, set ``on_existing: keep``. Using ``keep_and_warn`` instead will emit a warning if this happens, and ``keep_and_fail`` will make the module fail.
+If you want to assert that a record has a certain value, set :ansopt:`community.dns.hosttech_dns_record_set#module:on_existing=keep`. Using :ansval:`keep_and_warn` instead will emit a warning if this happens, and :ansval:`keep_and_fail` will make the module fail.
 
-To delete values, you can either overwrite the values with value ``[]``, or use ``state: absent``:
+To delete values, you can either overwrite the values with value :ansval:`[]`, or use :ansopt:`community.dns.hosttech_dns_record_set#module:state=absent`:
 
 .. code-block:: yaml+jinja
 
@@ -290,7 +290,7 @@ To delete values, you can either overwrite the values with value ``[]``, or use 
         value:
           - '::1'
 
-In the third example, ``on_existing: keep_and_fail`` is present and an explicit value and TTL are given. This makes the module remove the current value only if there's a AAAA record for ``www.example.com`` whose current value is ``::1`` and whose TTL is 300. If another value is set, the module will not make any change, but fail. This can be useful to not accidentally remove values you do not want to change. To issue a warning instead of failing, use ``on_existing: keep_and_warn``, and to simply not do a change without any indication of this situation, use ``on_existing: keep``.
+In the third example, :ansopt:`community.dns.hosttech_dns_record_set#module:on_existing=keep_and_fail` is present and an explicit value and TTL are given. This makes the module remove the current value only if there's a AAAA record for ``www.example.com`` whose current value is ``::1`` and whose TTL is 300. If another value is set, the module will not make any change, but fail. This can be useful to not accidentally remove values you do not want to change. To issue a warning instead of failing, use :ansopt:`community.dns.hosttech_dns_record_set#module:on_existing=keep_and_warn`, and to simply not do a change without any indication of this situation, use :ansopt:`community.dns.hosttech_dns_record_set#module:on_existing=keep`.
 
 Bulk synchronization of DNS record sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -304,7 +304,7 @@ The following example shows up to set/update multiple records at once:
     - name: Make sure that multiple records are present
       community.dns.hosttech_dns_record_sets:
         zone_name: example.com
-        records:
+        record_sets:
           - prefix: www
             type: A
             value:
@@ -315,7 +315,7 @@ The following example shows up to set/update multiple records at once:
             value:
               - '::1'
 
-The next example shows how to make sure that only the given records are available and all other records are deleted. Note that for the ``type: NS`` record we used ``ignore: true``, which allows us to skip the value. It tells the module that it should not touch the ``NS`` record for ``example.com``.
+The next example shows how to make sure that only the given records are available and all other records are deleted. Note that for the :ansopt:`community.dns.hosttech_dns_record_sets#module:record_sets[].type=NS` record we used :ansopt:`community.dns.hosttech_dns_record_sets#module:record_sets[].ignore=true`, which allows us to skip the value. It tells the module that it should not touch the ``NS`` record for ``example.com``.
 
 .. code-block:: yaml+jinja
 
@@ -323,7 +323,7 @@ The next example shows how to make sure that only the given records are availabl
       community.dns.hosttech_dns_record_sets:
         zone_name: example.com
         prune: true
-        records:
+        record_sets:
           - prefix: www
             type: A
             value:

--- a/plugins/doc_fragments/filters.py
+++ b/plugins/doc_fragments/filters.py
@@ -26,8 +26,8 @@ options:
     keep_unknown_suffix:
         description:
             - This treats unknown TLDs as valid public suffixes. So for example the public suffix
-              of C(example.tlddoesnotexist) is C(.tlddoesnotexist) if this is C(true). If set to
-              C(false), it will return an empty string in this case.
+              of C(example.tlddoesnotexist) is C(.tlddoesnotexist) if this is V(true). If set to
+              V(false), it will return an empty string in this case.
             - This option corresponds to whether the global wildcard rule C(*) in the Public
               Suffix List is used or not.
         type: boolean
@@ -40,17 +40,17 @@ options:
         description:
             - This controls the behavior in case there is no label in front of the public suffix.
               This is the case if the DNS name itself is a public suffix.
-            - If set to C(false), in this case the public suffix is treated as a registrable domain.
-            - If set to C(true) (default), the registrable domain of a public suffix is interpreted as an
+            - If set to V(false), in this case the public suffix is treated as a registrable domain.
+            - If set to V(true) (default), the registrable domain of a public suffix is interpreted as an
               empty string.
         type: boolean
         default: true
     keep_unknown_suffix:
         description:
             - This treats unknown TLDs as valid public suffixes. So for example the public suffix of
-              C(example.tlddoesnotexist) is C(.tlddoesnotexist) if this is C(true), and hence the
+              C(example.tlddoesnotexist) is C(.tlddoesnotexist) if this is V(true), and hence the
               registrable domain of C(www.example.tlddoesnotexist) is C(example.tlddoesnotexist).
-              If set to C(false), the registrable domain of C(www.example.tlddoesnotexist) is
+              If set to V(false), the registrable domain of C(www.example.tlddoesnotexist) is
               C(tlddoesnotexist).
             - This option corresponds to whether the global wildcard rule C(*) in the Public Suffix List
               is used or not.

--- a/plugins/doc_fragments/hetzner.py
+++ b/plugins/doc_fragments/hetzner.py
@@ -16,7 +16,7 @@ options:
     hetzner_token:
         description:
           - The token for the Hetzner API.
-          - If not provided, will be read from the environment variable C(HETZNER_DNS_TOKEN).
+          - If not provided, will be read from the environment variable E(HETZNER_DNS_TOKEN).
         aliases:
           - api_token
         type: str
@@ -76,17 +76,19 @@ options:
             record:
                 description:
                   - The full DNS record to create or delete.
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix)
+                      must be specified.
                 type: str
             prefix:
                 description:
                   - The prefix of the DNS record.
-                  - This is the part of I(record) before I(zone_name). For example,
-                      if the record to be modified is C(www.example.com) for the zone
-                      C(example.com), the prefix is C(www). If the record in this
-                      example would be C(example.com), the prefix would be C('') (empty
-                      string).
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - This is the part of O(record_sets[].record) before O(zone_name).
+                      For example, if the record to be modified is C(www.example.com)
+                      for the zone C(example.com), the prefix is V(www). If the record
+                      in this example would be C(example.com), the prefix would be
+                      V('') (empty string).
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix)
+                      must be specified.
                 type: str
             ttl:
                 description:
@@ -119,13 +121,13 @@ options:
                   - YAML lists or multiple comma-spaced values are allowed.
                   - When deleting a record all values for the record must be specified
                       or it will not be deleted.
-                  - Must be specified if I(ignore=false).
+                  - Must be specified if O(record_sets[].ignore=false).
                 type: list
                 elements: str
             ignore:
                 description:
-                  - If set to C(true), I(value) will be ignored.
-                  - This is useful when I(prune=true), but you do not want certain
+                  - If set to V(true), O(record_sets[].value) will be ignored.
+                  - This is useful when O(prune=true), but you do not want certain
                       entries to be removed without having to know their current value.
                 type: bool
                 default: false

--- a/plugins/doc_fragments/hosttech.py
+++ b/plugins/doc_fragments/hosttech.py
@@ -19,20 +19,20 @@ options:
     hosttech_username:
         description:
           - The username for the Hosttech API user.
-          - If provided, I(hosttech_password) must also be provided.
-          - Mutually exclusive with I(hosttech_token).
+          - If provided, O(hosttech_password) must also be provided.
+          - Mutually exclusive with O(hosttech_token).
         type: str
     hosttech_password:
         description:
           - The password for the Hosttech API user.
-          - If provided, I(hosttech_username) must also be provided.
-          - Mutually exclusive with I(hosttech_token).
+          - If provided, O(hosttech_username) must also be provided.
+          - Mutually exclusive with O(hosttech_token).
         type: str
     hosttech_token:
         description:
           - The password for the Hosttech API user.
-          - Mutually exclusive with I(hosttech_username) and I(hosttech_password).
-          - Since community.dns 1.2.0, the alias I(api_token) can be used.
+          - Mutually exclusive with O(hosttech_username) and O(hosttech_password).
+          - Since community.dns 1.2.0, the alias O(ignore:api_token) can be used.
         aliases:
           - api_token
         type: str
@@ -97,17 +97,19 @@ options:
             record:
                 description:
                   - The full DNS record to create or delete.
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix)
+                      must be specified.
                 type: str
             prefix:
                 description:
                   - The prefix of the DNS record.
-                  - This is the part of I(record) before I(zone_name). For example,
-                      if the record to be modified is C(www.example.com) for the zone
-                      C(example.com), the prefix is C(www). If the record in this
-                      example would be C(example.com), the prefix would be C('') (empty
-                      string).
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - This is the part of O(record_sets[].record) before O(zone_name).
+                      For example, if the record to be modified is C(www.example.com)
+                      for the zone C(example.com), the prefix is V(www). If the record
+                      in this example would be C(example.com), the prefix would be
+                      V('') (empty string).
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix)
+                      must be specified.
                 type: str
             ttl:
                 description:
@@ -136,13 +138,13 @@ options:
                   - YAML lists or multiple comma-spaced values are allowed.
                   - When deleting a record all values for the record must be specified
                       or it will not be deleted.
-                  - Must be specified if I(ignore=false).
+                  - Must be specified if O(record_sets[].ignore=false).
                 type: list
                 elements: str
             ignore:
                 description:
-                  - If set to C(true), I(value) will be ignored.
-                  - This is useful when I(prune=true), but you do not want certain
+                  - If set to V(true), O(record_sets[].value) will be ignored.
+                  - This is useful when O(prune=true), but you do not want certain
                       entries to be removed without having to know their current value.
                 type: bool
                 default: false

--- a/plugins/doc_fragments/inventory_records.py
+++ b/plugins/doc_fragments/inventory_records.py
@@ -17,20 +17,20 @@ description:
     - Records are matched by prefix / record name and value.
 
 notes:
-    - The I(zone_name) and I(zone_id) options can be templated.
+    - The O(zone_name) and O(zone_id) options can be templated.
 
 options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
     filters:
         description:
           - A dictionary of filter value pairs.

--- a/plugins/doc_fragments/module_record.py
+++ b/plugins/doc_fragments/module_record.py
@@ -28,26 +28,26 @@ options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
     record:
         description:
           - The full DNS record to create or delete.
-          - Exactly one of I(record) and I(prefix) must be specified.
+          - Exactly one of O(record) and O(prefix) must be specified.
         type: str
     prefix:
         description:
           - The prefix of the DNS record.
-          - This is the part of I(record) before I(zone_name). For example, if the record to be modified is C(www.example.com)
-            for the zone C(example.com), the prefix is C(www). If the record in this example would be C(example.com), the
-            prefix would be C('') (empty string).
-          - Exactly one of I(record) and I(prefix) must be specified.
+          - This is the part of O(record) before O(zone_name). For example, if the record to be modified is C(www.example.com)
+            for the zone C(example.com), the prefix is V(www). If the record in this example would be C(example.com), the
+            prefix would be V('') (empty string).
+          - Exactly one of O(record) and O(prefix) must be specified.
         type: str
     ttl:
         description:

--- a/plugins/doc_fragments/module_record_info.py
+++ b/plugins/doc_fragments/module_record_info.py
@@ -27,30 +27,30 @@ options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
     record:
         description:
           - The full DNS record to retrieve.
-          - If I(what) is C(single_record) or C(all_types_for_record), exactly one of I(record) and I(prefix) is required.
+          - If O(what) is V(single_record) or V(all_types_for_record), exactly one of O(record) and O(prefix) is required.
         type: str
     prefix:
         description:
           - The prefix of the DNS record.
-          - This is the part of I(record) before I(zone_name). For example, if the record to be modified is C(www.example.com)
-            for the zone C(example.com), the prefix is C(www). If the record in this example would be C(example.com), the
-            prefix would be C('') (empty string).
-          - If I(what) is C(single_record) or C(all_types_for_record), exactly one of I(record) and I(prefix) is required.
+          - This is the part of O(record) before O(zone_name). For example, if the record to be modified is C(www.example.com)
+            for the zone C(example.com), the prefix is V(www). If the record in this example would be C(example.com), the
+            prefix would be V('') (empty string).
+          - If O(what) is V(single_record) or V(all_types_for_record), exactly one of O(record) and O(prefix) is required.
         type: str
     type:
         description:
           - The type of DNS record to retrieve.
-          - Required if I(what) is C(single_record).
+          - Required if O(what) is V(single_record).
         type: str
 '''

--- a/plugins/doc_fragments/module_record_set.py
+++ b/plugins/doc_fragments/module_record_set.py
@@ -25,33 +25,32 @@ options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         version_added: 0.2.0
     record:
         description:
           - The full DNS record to create or delete.
-          - Exactly one of I(record) and I(prefix) must be specified.
+          - Exactly one of O(record) and O(prefix) must be specified.
         type: str
     prefix:
         description:
           - The prefix of the DNS record.
-          - This is the part of I(record) before I(zone_name). For example, if the record to be modified is C(www.example.com)
-            for the zone C(example.com), the prefix is C(www). If the record in this example would be C(example.com), the
-            prefix would be C('') (empty string).
-          - Exactly one of I(record) and I(prefix) must be specified.
+          - This is the part of O(record) before O(zone_name). For example, if the record to be modified is C(www.example.com)
+            for the zone C(example.com), the prefix is V(www). If the record in this example would be C(example.com), the
+            prefix would be V('') (empty string).
+          - Exactly one of O(record) and O(prefix) must be specified.
         type: str
         version_added: 0.2.0
     ttl:
         description:
           - The TTL to give the new record, in seconds.
-          - Will be ignored if I(state=absent) and I(on_existing=replace).
         type: int
     type:
         description:
@@ -64,22 +63,22 @@ options:
           - YAML lists or multiple comma-spaced values are allowed.
           - When deleting a record all values for the record must be specified or it will
             not be deleted.
-          - Must be specified if I(state=present) or when I(on_existing) is not C(replace).
-          - Will be ignored if I(state=absent) and I(on_existing=replace).
+          - Must be specified if O(state=present) or when O(on_existing) is not V(replace).
+          - Will be ignored if O(state=absent) and O(on_existing=replace).
         type: list
         elements: str
     on_existing:
         description:
           - This option defines the behavior if the record set already exists, but differs from the specified record set.
-            For this comparison, I(value) and I(ttl) are used for all records of type I(type) matching the I(prefix) resp. I(record).
-          - If set to C(replace), the record will be updated (I(state=present)) or removed (I(state=absent)).
-            This is the old I(overwrite=true) behavior.
-          - If set to C(keep_and_fail), the module will fail and not modify the records.
-            This is the old I(overwrite=false) behavior if I(state=present).
-          - If set to C(keep_and_warn), the module will warn and not modify the records.
-          - If set to C(keep), the module will not modify the records.
-            This is the old I(overwrite=false) behavior if I(state=absent).
-          - If I(state=absent) and the value is not C(replace), I(value) must be specified.
+            For this comparison, O(value) and O(ttl) are used for all records of type O(type) matching the O(prefix) resp. O(record).
+          - If set to V(replace), the record will be updated (O(state=present)) or removed (O(state=absent)).
+            This is the old O(ignore:overwrite=true) behavior.
+          - If set to V(keep_and_fail), the module will fail and not modify the records.
+            This is the old O(ignore:overwrite=false) behavior if O(state=present).
+          - If set to V(keep_and_warn), the module will warn and not modify the records.
+          - If set to V(keep), the module will not modify the records.
+            This is the old O(ignore:overwrite=false) behavior if O(state=absent).
+          - If O(state=absent) and the value is not V(replace), O(value) must be specified.
         default: replace
         type: str
         choices:

--- a/plugins/doc_fragments/module_record_set_info.py
+++ b/plugins/doc_fragments/module_record_set_info.py
@@ -27,32 +27,32 @@ options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         version_added: 0.2.0
     record:
         description:
           - The full DNS record to retrieve.
-          - If I(what) is C(single_record) or C(all_types_for_record), exactly one of I(record) and I(prefix) is required.
+          - If O(what) is V(single_record) or V(all_types_for_record), exactly one of O(record) and O(prefix) is required.
         type: str
     prefix:
         description:
           - The prefix of the DNS record.
-          - This is the part of I(record) before I(zone_name). For example, if the record to be modified is C(www.example.com)
-            for the zone C(example.com), the prefix is C(www). If the record in this example would be C(example.com), the
-            prefix would be C('') (empty string).
-          - If I(what) is C(single_record) or C(all_types_for_record), exactly one of I(record) and I(prefix) is required.
+          - This is the part of O(record) before O(zone_name). For example, if the record to be modified is C(www.example.com)
+            for the zone C(example.com), the prefix is V(www). If the record in this example would be C(example.com), the
+            prefix would be V('') (empty string).
+          - If O(what) is V(single_record) or V(all_types_for_record), exactly one of O(record) and O(prefix) is required.
         type: str
         version_added: 0.2.0
     type:
         description:
           - The type of DNS record to retrieve.
-          - Required if I(what) is C(single_record).
+          - Required if O(what) is V(single_record).
         type: str
 '''

--- a/plugins/doc_fragments/module_record_sets.py
+++ b/plugins/doc_fragments/module_record_sets.py
@@ -14,27 +14,27 @@ class ModuleDocFragment(object):
     DOCUMENTATION = r'''
 description:
     - The module allows to set, modify and delete multiple DNS record sets at once.
-    - With the I(purge) option, it is also possible to delete existing record sets
+    - With the O(prune) option, it is also possible to delete existing record sets
       that are not mentioned in the module parameters. With this, it is possible
       to synchronize the expected state of a DNS zone with the expected state.
-    - "It is possible to ignore certain record sets by specifying I(ignore: true) for
+    - "It is possible to ignore certain record sets by specifying O(record_sets[].ignore=true) for
        that record set."
 
 options:
     zone_name:
         description:
           - The DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to modify.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
     prune:
         description:
-          - If set to C(true), will remove all existing records in the zone that are not listed in I(records).
+          - If set to V(true), will remove all existing records in the zone that are not listed in O(record_sets).
         type: bool
         default: false
     record_sets:
@@ -50,15 +50,15 @@ options:
             record:
                 description:
                   - The full DNS record to create or delete.
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix) must be specified.
                 type: str
             prefix:
                 description:
                   - The prefix of the DNS record.
-                  - This is the part of I(record) before I(zone_name). For example, if the record to be modified is C(www.example.com)
-                    for the zone C(example.com), the prefix is C(www). If the record in this example would be C(example.com), the
-                    prefix would be C('') (empty string).
-                  - Exactly one of I(record) and I(prefix) must be specified.
+                  - This is the part of O(record_sets[].record) before O(zone_name). For example, if the record to be modified is C(www.example.com)
+                    for the zone C(example.com), the prefix is V(www). If the record in this example would be C(example.com), the
+                    prefix would be V('') (empty string).
+                  - Exactly one of O(record_sets[].record) and O(record_sets[].prefix) must be specified.
                 type: str
             ttl:
                 description:
@@ -75,13 +75,13 @@ options:
                   - YAML lists or multiple comma-spaced values are allowed.
                   - When deleting a record all values for the record must be specified or it will
                     not be deleted.
-                  - Must be specified if I(ignore=false).
+                  - Must be specified if O(record_sets[].ignore=false).
                 type: list
                 elements: str
             ignore:
                 description:
-                  - If set to C(true), I(value) will be ignored.
-                  - This is useful when I(prune=true), but you do not want certain entries to be removed
+                  - If set to V(true), O(record_sets[].value) will be ignored.
+                  - This is useful when O(prune=true), but you do not want certain entries to be removed
                     without having to know their current value.
                 type: bool
                 default: false

--- a/plugins/doc_fragments/module_zone_info.py
+++ b/plugins/doc_fragments/module_zone_info.py
@@ -16,13 +16,13 @@ options:
     zone_name:
         description:
           - The DNS zone to query.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         type: str
         aliases:
           - zone
     zone_id:
         description:
           - The ID of the DNS zone to query.
-          - Exactly one of I(zone_name) and I(zone_id) must be specified.
+          - Exactly one of O(zone_name) and O(zone_id) must be specified.
         version_added: 0.2.0
 '''

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -53,7 +53,7 @@ options:
         default: unquoted
     txt_character_encoding:
         description:
-            - Whether to treat numeric escape sequences (C(\xyz)) as octal or decimal numbers.
+            - Whether to treat numeric escape sequences (V(\\xyz)) as octal or decimal numbers.
               This is only used when O(txt_transformation=quoted).
             - The current default is V(octal) which is deprecated. It will change to V(decimal) in
               community.dns 3.0.0. The value V(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -28,23 +28,23 @@ options:
         description:
             - Determines how TXT entry values are converted between the API and this module's
               input and output.
-            - The value C(api) means that values are returned from this module as they are returned
+            - The value V(api) means that values are returned from this module as they are returned
               from the API, and pushed to the API as they have been passed to this module. For
               idempotency checks, the input string will be compared to the strings returned by the
               API. The API might automatically transform some values, like splitting long values or
               adding quotes, which can cause problems with idempotency.
-            - The value C(unquoted) automatically transforms values so that you can pass in unquoted
+            - The value V(unquoted) automatically transforms values so that you can pass in unquoted
               values, and the module will return unquoted values. If you pass in quoted values, they
               will be double-quoted.
-            - The value C(quoted) automatically transforms values so that you must use quoting for values
+            - The value V(quoted) automatically transforms values so that you must use quoting for values
               that contain spaces, characters such as quotation marks and backslashes, and that are
               longer than 255 bytes. It also makes sure to return values from the API in a normalized
               encoding.
-            - The default value, C(unquoted), ensures that you can work with values without having
-              to care about how to correctly quote for DNS. Most users should use one of C(unquoted)
-              or C(quoted), but not C(api).
+            - The default value, V(unquoted), ensures that you can work with values without having
+              to care about how to correctly quote for DNS. Most users should use one of V(unquoted)
+              or V(quoted), but not V(api).
             - B(Note:) the conversion code assumes UTF-8 encoding for values. If you need another
-              encoding use I(txt_transformation=api) and handle the encoding yourself.
+              encoding use O(txt_transformation=api) and handle the encoding yourself.
         type: str
         choices:
             - api
@@ -54,9 +54,9 @@ options:
     txt_character_encoding:
         description:
             - Whether to treat numeric escape sequences (C(\xyz)) as octal or decimal numbers.
-              This is only used when I(txt_transformation=quoted).
-            - The current default is C(octal) which is deprecated. It will change to C(decimal) in
-              community.dns 3.0.0. The value C(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
+              This is only used when O(txt_transformation=quoted).
+            - The current default is V(octal) which is deprecated. It will change to V(decimal) in
+              community.dns 3.0.0. The value V(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
         type: str
         choices:
             - decimal

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -23,7 +23,7 @@ description:
 
 options:
     plugin:
-        description: The name of this plugin. Should always be set to C(community.dns.hetzner_dns_records) for this plugin to recognize it as its own.
+        description: The name of this plugin. Should always be set to V(community.dns.hetzner_dns_records) for this plugin to recognize it as its own.
         # TODO: add `required: true` in 3.0.0
         # required: true
         choices:

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -39,7 +39,7 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
 
 notes:
-    - The provider-specific I(hetzner_token) option can be templated.
+    - The provider-specific O(hetzner_token) option can be templated.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -23,7 +23,7 @@ description:
 
 options:
     plugin:
-        description: The name of this plugin. Should always be set to C(community.dns.hosttech_dns_records) for this plugin to recognize it as its own.
+        description: The name of this plugin. Should always be set to V(community.dns.hosttech_dns_records) for this plugin to recognize it as its own.
         # TODO: add `required: true` in 3.0.0
         # required: true
         choices:

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -47,7 +47,7 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
 
 notes:
-    - The provider-specific I(hosttech_username), I(hosttech_password), and I(hosttech_token) options can be templated.
+    - The provider-specific O(hosttech_username), O(hosttech_password), and O(hosttech_token) options can be templated.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -37,6 +37,11 @@ attributes:
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>
     - Felix Fontein (@felixfontein)
+
+seealso:
+    - module: community.dns.hetzner_dns_record_set_info
+    - plugin: community.dns.hetzner_dns_records
+      plugin_type: inventory
 '''
 
 EXAMPLES = '''
@@ -58,7 +63,7 @@ records:
     description: The list of fetched records.
     type: list
     elements: dict
-    returned: success and I(what) is not C(single_record)
+    returned: success and O(what) is not V(single_record)
     contains:
         record:
             description: The record name.
@@ -75,7 +80,7 @@ records:
         ttl:
             description:
               - The TTL.
-              - Will return C(none) if the zone's default TTL is used.
+              - Will return V(none) if the zone's default TTL is used.
             type: int
             sample: 3600
         value:

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -37,6 +37,11 @@ attributes:
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>
     - Felix Fontein (@felixfontein)
+
+seealso:
+    - module: community.dns.hetzner_dns_record_info
+    - plugin: community.dns.hetzner_dns_records
+      plugin_type: inventory
 '''
 
 EXAMPLES = '''
@@ -57,7 +62,7 @@ RETURN = '''
 set:
     description: The fetched record set. Is empty if record set does not exist.
     type: dict
-    returned: success and I(what) is C(single_record)
+    returned: success and O(what) is V(single_record)
     contains:
         record:
             description: The record name.
@@ -76,7 +81,7 @@ set:
             description:
               - The TTL.
               - If there are records in this set with different TTLs, the minimum of the TTLs will be presented here.
-              - Will return C(none) if the zone's default TTL is used.
+              - Will return V(none) if the zone's default TTL is used.
             type: int
             sample: 3600
         ttls:
@@ -109,7 +114,7 @@ sets:
     description: The list of fetched record sets.
     type: list
     elements: dict
-    returned: success and I(what) is not C(single_record)
+    returned: success and O(what) is not V(single_record)
     contains:
         record:
             description: The record name.
@@ -128,7 +133,7 @@ sets:
             description:
               - The TTL.
               - If there are records in this set with different TTLs, the minimum of the TTLs will be presented here.
-              - Will return C(none) if the zone's default TTL is used.
+              - Will return V(none) if the zone's default TTL is used.
             type: int
             sample: 3600
         ttls:

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -121,7 +121,7 @@ zone_info:
         status:
             description:
                 - Status of the zone.
-                - Can be one of C(verified), C(failed) and C(pending).
+                - Can be one of V(verified), V(failed) and V(pending).
             type: str
             sample: verified
             # choices:

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -36,6 +36,11 @@ attributes:
 
 author:
     - Felix Fontein (@felixfontein)
+
+seealso:
+    - module: community.dns.hosttech_dns_record_set_info
+    - plugin: community.dns.hosttech_dns_records
+      plugin_type: inventory
 '''
 
 EXAMPLES = '''
@@ -57,7 +62,7 @@ records:
     description: The list of fetched records.
     type: list
     elements: dict
-    returned: success and I(what) is not C(single_record)
+    returned: success and O(what) is not V(single_record)
     contains:
         record:
             description: The record name.

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -19,7 +19,7 @@ version_added: 0.1.0
 
 description:
     - "Retrieves DNS record sets in Hosttech DNS service."
-    - This module was renamed from C(community.dns.hosttech_dns_record_info) to C(community.dns.hosttech_dns_record_set_info)
+    - This module was renamed from C(community.dns.hosttech_dns_record_info) to M(community.dns.hosttech_dns_record_set_info)
       in community.dns 2.0.0.
 
 extends_documentation_fragment:

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -38,6 +38,11 @@ attributes:
 
 author:
     - Felix Fontein (@felixfontein)
+
+seealso:
+    - module: community.dns.hosttech_dns_record_info
+    - plugin: community.dns.hosttech_dns_records
+      plugin_type: inventory
 '''
 
 EXAMPLES = '''
@@ -58,7 +63,7 @@ RETURN = '''
 set:
     description: The fetched record set. Is empty if record set does not exist.
     type: dict
-    returned: success and I(what) is C(single_record)
+    returned: success and O(what=single_record)
     contains:
         record:
             description: The record name.
@@ -109,7 +114,7 @@ sets:
     description: The list of fetched record sets.
     type: list
     elements: dict
-    returned: success and I(what) is not C(single_record)
+    returned: success and O(what=single_record)
     contains:
         record:
             description: The record name.

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -80,22 +80,22 @@ zone_info:
             description:
                 - Whether DNSSEC is enabled for the zone or not.
             type: bool
-            returned: When I(hosttech_token) has been specified.
+            returned: When O(hosttech_token) has been specified.
         dnssec_email:
             description:
                 - The email address contacted when the DNSSEC key is changed.
-                - Is C(none) if DNSSEC is not enabled.
+                - Is V(none) if DNSSEC is not enabled.
             type: str
-            returned: When I(hosttech_token) has been specified.
+            returned: When O(hosttech_token) has been specified.
         ds_records:
             description:
                 - The DS records.
                 - See L(Section 5 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-5) and
                   L(Section 2.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-2.1) for details.
-                - Is C(none) if DNSSEC is not enabled.
+                - Is V(none) if DNSSEC is not enabled.
             type: list
             elements: dict
-            returned: When I(hosttech_token) has been specified.
+            returned: When O(hosttech_token) has been specified.
             contains:
                 algorithm:
                     description:

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -40,7 +40,7 @@ options:
         suboptions:
             name:
                 description:
-                    - A DNS name, like C(www.example.com).
+                    - A DNS name, like V(www.example.com).
                 type: str
                 required: true
             values:
@@ -51,17 +51,17 @@ options:
                 required: true
             mode:
                 description:
-                    - Comparison modes for the values in I(values).
-                    - If C(subset), I(values) should be a (not necessarily proper) subset of the TXT values set for
+                    - Comparison modes for the values in O(records[].values).
+                    - If V(subset), O(records[].values) should be a (not necessarily proper) subset of the TXT values set for
                       the DNS name.
-                    - If C(superset), I(values) should be a (not necessarily proper) superset of the TXT values set
+                    - If V(superset), O(records[].values) should be a (not necessarily proper) superset of the TXT values set
                       for the DNS name.
                       This includes the case that no TXT entries are set.
-                    - If C(superset_not_empty), I(values) should be a (not necessarily proper) superset of the TXT
+                    - If V(superset_not_empty), O(records[].values) should be a (not necessarily proper) superset of the TXT
                       values set for the DNS name, assuming at least one TXT record is present.
-                    - If C(equals), I(values) should be the same set of strings as the TXT values for the DNS name
+                    - If V(equals), O(records[].values) should be the same set of strings as the TXT values for the DNS name
                       (up to order).
-                    - If C(equals_ordered), I(values) should be the same ordered list of strings as the TXT values
+                    - If V(equals_ordered), O(records[].values) should be the same ordered list of strings as the TXT values
                       for the DNS name.
                 type: str
                 default: subset
@@ -93,9 +93,9 @@ options:
         default: 10
     always_ask_default_resolver:
         description:
-            - When set to C(true) (default), will use the default resolver to find the authoritative nameservers
+            - When set to V(true) (default), will use the default resolver to find the authoritative nameservers
               of a subzone.
-            - When set to C(false), will use the authoritative nameservers of the parent zone to find the
+            - When set to V(false), will use the authoritative nameservers of the parent zone to find the
               authoritative nameservers of a subzone. This only makes sense when the nameservers were recently
               changed and haven't propagated.
         type: bool
@@ -124,7 +124,7 @@ RETURN = r'''
 records:
     description:
         - Results on the TXT records queried.
-        - The entries are in a 1:1 correspondence to the entries of the I(records) parameter,
+        - The entries are in a 1:1 correspondence to the entries of the O(records) parameter,
           in exactly the same order.
     returned: always
     type: list

--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -17,7 +17,7 @@ def main():
     suffix = ':{env}'.format(env=env["ANSIBLE_COLLECTIONS_PATH"]) if 'ANSIBLE_COLLECTIONS_PATH' in env else ''
     env['ANSIBLE_COLLECTIONS_PATH'] = '{root}{suffix}'.format(root=os.path.dirname(os.path.dirname(os.path.dirname(os.getcwd()))), suffix=suffix)
     p = subprocess.run(
-        ['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--disallow-semantic-markup', '--skip-rstcheck', '.'],
+        ['antsibull-docs', 'lint-collection-docs', '--plugin-docs', '--skip-rstcheck', '.'],
         env=env,
         check=False,
     )

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,8 @@
+docs/docsite/rst/filter_guide.rst rstcheck
+docs/docsite/rst/hosttech_guide.rst rstcheck
+docs/docsite/rst/hetzner_guide.rst rstcheck
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,5 @@
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,1 +1,5 @@
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,1 +1,5 @@
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,5 @@
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,1 +1,8 @@
+docs/docsite/rst/filter_guide.rst rstcheck
+docs/docsite/rst/hosttech_guide.rst rstcheck
+docs/docsite/rst/hetzner_guide.rst rstcheck
+plugins/modules/hetzner_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hetzner_dns_record_set_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_info.py validate-modules:invalid-documentation
+plugins/modules/hosttech_dns_record_set_info.py validate-modules:invalid-documentation
 plugins/public_suffix_list.dat no-smart-quotes


### PR DESCRIPTION
##### SUMMARY
Depends on https://github.com/ansible/ansible/pull/74937 and ~~https://github.com/ansible-community/antsibull/pull/281~~ https://github.com/ansible-community/antsibull-docs/pull/4.

The result can be seen here:
- https://ansible.fontein.de/collections/community/dns/hosttech_dns_records_module.html#synopsis for `O(ignore=true)` in RST;
- https://ansible.fontein.de/collections/community/dns/hosttech_dns_record_info_module.html#return-sets for `O(what=single_record)` in HTML;
- https://ansible.fontein.de/collections/community/dns/hosttech_dns_records_module.html#parameter-records/prefix for simple `O()` and `V()` usages;
- https://ansible.fontein.de/collections/community/general/dependent_lookup.html#parameter-_raw for `P(ansible.builtin.dict2items#filter)` in HTML;

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
extra docs
