### PR TITLE
Replace ansible.module_utils._text by ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/ansible-core-_text.yml
+++ b/changelogs/fragments/ansible-core-_text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Avoid internal ansible-core module_utils in favor of equivalent public API available since at least Ansible 2.9 (https://github.com/ansible-collections/community.dns/pull/24)."

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -13,7 +13,7 @@ import json
 import time
 
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 from ansible_collections.community.dns.plugins.module_utils.record import (

--- a/plugins/module_utils/hosttech/wsdl_api.py
+++ b/plugins/module_utils/hosttech/wsdl_api.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 from ansible.module_utils.six import raise_from
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
     DNSRecord,

--- a/plugins/module_utils/names.py
+++ b/plugins/module_utils/names.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import re
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 _ASCII_PRINTABLE_MATCHER = re.compile(r'^[\x20-\x7e]*$')

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import traceback
 
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     import dns

--- a/plugins/module_utils/wsdl.py
+++ b/plugins/module_utils/wsdl.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import open_url, urllib_error, NoSSLError, ConnectionError
 
 try:

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -174,7 +174,7 @@ except ImportError:
     from time import clock as monotonic
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolveDirectlyFromNameServers,


### PR DESCRIPTION
##### SUMMARY
While the private API `ansible.module_utils._text` was the default place to get `to_text`, `to_bytes` and `to_native` for a long time, at least since Ansible 2.9 there's a non-private alternative: `ansible.module_utils.common.text.converters`. So let's use it :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various plugins
