### PR TITLE
Fix extra-tests name

### DIFF
--- a/.github/workflows/extra-tests.yml
+++ b/.github/workflows/extra-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: extra-tests
 on:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:


### PR DESCRIPTION
##### SUMMARY
When adding the extra tests, I forgot to give them another workflow name. Right now the have the same name as the standard ansible-test workflow (CI).

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI
