### PR TITLE
Add more zone information

### DIFF
--- a/changelogs/fragments/38-zone-extra-info.yml
+++ b/changelogs/fragments/38-zone-extra-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "hosttech_dns_zone_info - return extra information as ``zone_info`` (https://github.com/ansible-collections/community.dns/pull/38)."

--- a/plugins/module_utils/hetzner/api.py
+++ b/plugins/module_utils/hetzner/api.py
@@ -46,7 +46,10 @@ from ansible_collections.community.dns.plugins.module_utils.zone_record_api impo
 def _create_zone_from_json(source):
     zone = DNSZone(source['name'])
     zone.id = source['id']
-    # See https://dns.hetzner.com/api-docs/#operation/GetZone for all other return values
+    info = source.copy()
+    info.pop('name')
+    info.pop('id')
+    zone.info = info
     return zone
 
 

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -74,9 +74,13 @@ def _create_record_from_json(source, type=None):
 def _create_zone_from_json(source):
     zone = DNSZone(source['name'])
     zone.id = source['id']
-    # zone.email = source.get('email')
-    # zone.ttl = int(source['ttl'])
-    # zone.nameserver = source['nameserver']
+    zone.info = dict(
+        dnssec=source['dnssec'],
+        dnssec_email=source.get('dnssec_email'),
+        ds_records=source.get('ds_records'),
+        email=source.get('email'),
+        ttl=source['ttl'],
+    )
     return zone
 
 

--- a/plugins/module_utils/hosttech/wsdl_api.py
+++ b/plugins/module_utils/hosttech/wsdl_api.py
@@ -50,11 +50,10 @@ def _create_record_from_encoding(source, type=None):
 def _create_zone_from_encoding(source, prefix=NOT_PROVIDED, record_type=NOT_PROVIDED):
     zone = DNSZone(source['name'])
     zone.id = source['id']
-    # zone.email = source.get('email')
-    # zone.ttl = int(source['ttl'])
-    # zone.nameserver = source['nameserver']
-    # zone.serial = source['serial']
-    # zone.template = source.get('template')
+    zone.info = dict(
+        email=source.get('email'),
+        ttl=source['ttl'],
+    )
     return DNSZoneWithRecords(
         zone,
         filter_records(

--- a/plugins/module_utils/module/zone_info.py
+++ b/plugins/module_utils/module/zone_info.py
@@ -64,6 +64,7 @@ def run_module(module, create_api, provider_information):
             changed=False,
             zone_name=zone.name,
             zone_id=zone.id,
+            zone_info=zone.info,
         )
     except DNSAPIAuthenticationError as e:
         module.fail_json(msg='Cannot authenticate: {0}'.format(e), error=str(e), exception=traceback.format_exc())

--- a/plugins/module_utils/zone.py
+++ b/plugins/module_utils/zone.py
@@ -8,15 +8,17 @@ __metaclass__ = type
 
 
 class DNSZone(object):
-    def __init__(self, name):
+    def __init__(self, name, info=None):
         self.id = None
         self.name = name
+        self.info = info or dict()
 
     def __str__(self):
         data = []
         if self.id is not None:
             data.append('id: {0}'.format(self.id))
         data.append('name: {0}'.format(self.name))
+        data.append('info: {0}'.format(self.info))
         return 'DNSZone(' + ', '.join(data) + ')'
 
     def __repr__(self):

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -66,80 +66,81 @@ zone_info:
         created:
             description:
                 - The time when the zone was created.
-            type: string
+            type: str
             sample: "2021-07-15T19:23:58Z"
         modified:
             description:
                 - The time the zone was last modified.
-            type: string
+            type: str
             sample: "2021-07-15T19:23:58Z"
         legacy_dns_host:
             description:
                 # TODO
                 - Unknown.
-            type: string
+            type: str
         legacy_ns:
             description:
                 - List of nameservers during import.
             type: list
-            elements: string
+            elements: str
         ns:
             description:
                 - List of nameservers the zone should have for using Hetzner's DNS.
             type: list
-            elements: string
+            elements: str
         owner:
             description:
                 - Owner of the zone.
-            type: string
+            type: str
         paused:
             description:
                 # TODO
                 - Unknown.
-            type: boolean
+            type: bool
             sample: true
         permission:
             description:
                 - Zone's permissions.
-            type: string
+            type: str
         project:
             description:
                 # TODO
                 - Unknown.
-            type: string
+            type: str
         registrar:
             description:
                 # TODO
                 - Unknown.
-            type: string
+            type: str
         status:
             description:
                 - Status of the zone.
-            type: string
+                - Can be one of C(verified), C(failed) and C(pending).
+            type: str
             sample: verified
-            choices:
-                - verified
-                - failed
-                - pending
+            # choices:
+            #     - verified
+            #     - failed
+            #     - pending
         ttl:
             description:
                 - TTL of zone.
-            type: integer
+            type: int
             sample: 0
         verified:
             description:
                 - Time when zone was verified.
-            type: string
+            type: str
             sample: "2021-07-15T19:23:58Z"
         records_count:
             description:
                 - Number of records associated to this zone.
-            type: integer
+            type: int
             sample: 0
         is_secondary_dns:
             description:
                 - Indicates whether the zone is a secondary DNS zone.
-            type: boolean
+            type: bool
             sample: true
         txt_verification:
             description:
@@ -151,11 +152,11 @@ zone_info:
                 name:
                     description:
                         - The TXT record's name.
-                    type: string
+                    type: str
                 token:
                     description:
                         - The TXT record's content.
-                    type: string
+                    type: str
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -55,6 +55,107 @@ zone_id:
     type: str
     returned: success
     sample: 23
+
+zone_info:
+    description:
+        - Extra information returned by the API.
+    type: dict
+    returned: success
+    sample: {'dnssec': True, 'dnssec_email': 'test@example.com', 'ds_records': [], 'email': 'test@example.com', 'ttl': 3600}
+    contains:
+        created:
+            description:
+                - The time when the zone was created.
+            type: string
+            sample: "2021-07-15T19:23:58Z"
+        modified:
+            description:
+                - The time the zone was last modified.
+            type: string
+            sample: "2021-07-15T19:23:58Z"
+        legacy_dns_host:
+            description:
+                # TODO
+                - Unknown.
+            type: string
+        legacy_ns:
+            description:
+                - List of nameservers during import.
+            type: list
+            elements: string
+        ns:
+            description:
+                - List of nameservers the zone should have for using Hetzner's DNS.
+            type: list
+            elements: string
+        owner:
+            description:
+                - Owner of the zone.
+            type: string
+        paused:
+            description:
+                # TODO
+                - Unknown.
+            type: boolean
+            sample: true
+        permission:
+            description:
+                - Zone's permissions.
+            type: string
+        project:
+            description:
+                # TODO
+                - Unknown.
+            type: string
+        registrar:
+            description:
+                # TODO
+                - Unknown.
+            type: string
+        status:
+            description:
+                - Status of the zone.
+            type: string
+            sample: verified
+            choices:
+                - verified
+                - failed
+                - pending
+        ttl:
+            description:
+                - TTL of zone.
+            type: integer
+            sample: 0
+        verified:
+            description:
+                - Time when zone was verified.
+            type: string
+            sample: "2021-07-15T19:23:58Z"
+        records_count:
+            description:
+                - Number of records associated to this zone.
+            type: integer
+            sample: 0
+        is_secondary_dns:
+            description:
+                - Indicates whether the zone is a secondary DNS zone.
+            type: boolean
+            sample: true
+        txt_verification:
+            description:
+                - Shape of the TXT record that has to be set to verify a zone.
+                - If name and token are empty, no TXT record needs to be set.
+            type: dict
+            sample: {'name': '', 'token': ''}
+            contains:
+                name:
+                    description:
+                        - The TXT record's name.
+                    type: string
+                token:
+                    description:
+                        - The TXT record's content.
+                    type: string
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -55,6 +55,81 @@ zone_id:
     type: int
     returned: success
     sample: 23
+
+zone_info:
+    description:
+        - Extra information returned by the API.
+    type: dict
+    returned: success
+    version_added: 2.0.0
+    sample: {'dnssec': True, 'dnssec_email': 'test@example.com', 'ds_records': [], 'email': 'test@example.com', 'ttl': 3600}
+    contains:
+        dnssec:
+            description:
+                - Whether DNSSEC is enabled for the zone or not.
+            type: bool
+            returned: When I(hosttech_token) has been specified.
+        dnssec_email:
+            description:
+                - The email address contacted when the DNSSEC key is changed.
+                - Is C(none) if DNSSEC is not enabled.
+            type: string
+            returned: When I(hosttech_token) has been specified.
+        ds_records:
+            description:
+                - The DS records.
+                - See L(Section 5 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-5) and
+                  L(Section 2.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-2.1) for details.
+                - Is C(none) if DNSSEC is not enabled.
+            type: list
+            elements: dict
+            returned: When I(hosttech_token) has been specified.
+            contains:
+                algorithm:
+                    description:
+                        - This value is the algorithm number of the DNSKEY RR referred to by the DS record.
+                        - A list of values can be found in L(Appendix A.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.1).
+                    type: integer
+                    sample: 8
+                digest:
+                    description:
+                        - A digest of the DNSKEY RR record this DS record refers to.
+                    type: string
+                    sample: 012356789ABCDEF0123456789ABCDEF012345678
+                digest_type:
+                    description:
+                        - This value identifies the algorithm used to construct the digest.
+                        - A list of values can be found in L(Appendix A.2 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.2).
+                    type: integer
+                    sample: 1
+                flags:
+                    description:
+                        - The Zone Key flag. See L(Section 2.1.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-2.1.1) for details.
+                    type: integer
+                    sample: 257
+                key_tag:
+                    description:
+                        - The Key Tag field lists the key tag of the DNSKEY RR referred to by the DS record.
+                    type: integer
+                    sample: 12345
+                protocol:
+                    description:
+                        - Must be 3 according to RFC 4034.
+                    type: integer
+                    sample: 3
+                public_key:
+                    description:
+                        - The public key material.
+                    type: string
+                    sample: MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=
+        email:
+            description:
+                - The zone's DNS contact mail in the SOA record.
+            type: string
+        ttl:
+            description:
+                - The zone's TTL.
+            type: integer
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -73,7 +73,7 @@ zone_info:
             description:
                 - The email address contacted when the DNSSEC key is changed.
                 - Is C(none) if DNSSEC is not enabled.
-            type: string
+            type: str
             returned: When I(hosttech_token) has been specified.
         ds_records:
             description:
@@ -89,47 +89,47 @@ zone_info:
                     description:
                         - This value is the algorithm number of the DNSKEY RR referred to by the DS record.
                         - A list of values can be found in L(Appendix A.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.1).
-                    type: integer
+                    type: int
                     sample: 8
                 digest:
                     description:
                         - A digest of the DNSKEY RR record this DS record refers to.
-                    type: string
+                    type: str
                     sample: 012356789ABCDEF0123456789ABCDEF012345678
                 digest_type:
                     description:
                         - This value identifies the algorithm used to construct the digest.
                         - A list of values can be found in L(Appendix A.2 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#appendix-A.2).
-                    type: integer
+                    type: int
                     sample: 1
                 flags:
                     description:
                         - The Zone Key flag. See L(Section 2.1.1 of RFC 4034,https://datatracker.ietf.org/doc/html/rfc4034#section-2.1.1) for details.
-                    type: integer
+                    type: int
                     sample: 257
                 key_tag:
                     description:
                         - The Key Tag field lists the key tag of the DNSKEY RR referred to by the DS record.
-                    type: integer
+                    type: int
                     sample: 12345
                 protocol:
                     description:
                         - Must be 3 according to RFC 4034.
-                    type: integer
+                    type: int
                     sample: 3
                 public_key:
                     description:
                         - The public key material.
-                    type: string
+                    type: str
                     sample: MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=
         email:
             description:
                 - The zone's DNS contact mail in the SOA record.
-            type: string
+            type: str
         ttl:
             description:
                 - The zone's TTL.
-            type: integer
+            type: int
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -121,7 +121,14 @@ zone_info:
                     description:
                         - The public key material.
                     type: str
-                    sample: MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=
+                    sample: >-
+                        MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa
+                        eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh
+                        HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb
+                        pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge
+                        kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm
+                        bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD
+                        lfceKgmKwEF=
         email:
             description:
                 - The zone's DNS contact mail in the SOA record.

--- a/tests/unit/plugins/module_utils/test_zone.py
+++ b/tests/unit/plugins/module_utils/test_zone.py
@@ -22,12 +22,13 @@ from ansible_collections.community.dns.plugins.module_utils.zone import (
 
 def test_zone_str_repr():
     Z1 = DNSZone('foo')
-    assert str(Z1) == 'DNSZone(name: foo)'
-    assert repr(Z1) == 'DNSZone(name: foo)'
+    assert str(Z1) == 'DNSZone(name: foo, info: {})'
+    assert repr(Z1) == 'DNSZone(name: foo, info: {})'
     Z2 = DNSZone('foo')
     Z2.id = 42
-    assert str(Z2) == 'DNSZone(id: 42, name: foo)'
-    assert repr(Z2) == 'DNSZone(id: 42, name: foo)'
+    Z2.info['foo'] = 'bar'
+    assert str(Z2) == "DNSZone(id: 42, name: foo, info: {'foo': 'bar'})"
+    assert repr(Z2) == "DNSZone(id: 42, name: foo, info: {'foo': 'bar'})"
 
 
 def test_zone_with_records_str_repr():
@@ -48,13 +49,13 @@ def test_zone_with_records_str_repr():
     A2.comment = 'test'
     ZZ1 = DNSZoneWithRecords(Z1, [A1])
     ZZ2 = DNSZoneWithRecords(Z2, [A1, A2])
-    assert str(ZZ1) == '(DNSZone(name: foo), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
-    assert repr(ZZ1) == 'DNSZoneWithRecords(DNSZone(name: foo), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
+    assert str(ZZ1) == '(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
+    assert repr(ZZ1) == 'DNSZoneWithRecords(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
     assert str(ZZ2) == (
-        '(DNSZone(id: 42, name: foo), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
+        '(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
         ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)])'
     )
     assert repr(ZZ2) == (
-        'DNSZoneWithRecords(DNSZone(id: 42, name: foo), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
+        'DNSZoneWithRecords(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
         ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)])'
     )

--- a/tests/unit/plugins/modules/hosttech.py
+++ b/tests/unit/plugins/modules/hosttech.py
@@ -401,7 +401,14 @@ HOSTTECH_JSON_ZONE_LIST_RESULT = {
                     'digest': '012356789ABCDEF0123456789ABCDEF012345678',
                     'flags': 257,
                     'protocol': 3,
-                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                    'public_key':
+                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                        'lfceKgmKwEF=',
                 },
                 {
                     'key_tag': 12345,
@@ -410,7 +417,14 @@ HOSTTECH_JSON_ZONE_LIST_RESULT = {
                     'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
                     'flags': 257,
                     'protocol': 3,
-                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                    'public_key':
+                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                        'lfceKgmKwEF=',
                 }
             ],
         },

--- a/tests/unit/plugins/modules/hosttech.py
+++ b/tests/unit/plugins/modules/hosttech.py
@@ -385,6 +385,35 @@ HOSTTECH_JSON_ZONE_LIST_RESULT = {
             "nameserver": "ns1.hosttech.ch",
             "dnssec": False,
         },
+        {
+            "id": 43,
+            "name": "foo.com",
+            "email": "test@foo.com",
+            "ttl": 10800,
+            "nameserver": "ns1.hosttech.ch",
+            'dnssec': True,
+            'dnssec_email': 'test@foo.com',
+            'ds_records': [
+                {
+                    'key_tag': 12345,
+                    'algorithm': 8,
+                    'digest_type': 1,
+                    'digest': '012356789ABCDEF0123456789ABCDEF012345678',
+                    'flags': 257,
+                    'protocol': 3,
+                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                },
+                {
+                    'key_tag': 12345,
+                    'algorithm': 8,
+                    'digest_type': 2,
+                    'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
+                    'flags': 257,
+                    'protocol': 3,
+                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                }
+            ],
+        },
     ],
 }
 

--- a/tests/unit/plugins/modules/test_hetzner_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_zone_info.py
@@ -128,6 +128,27 @@ class TestHetznerDNSZoneInfoJSON(BaseTestModule):
         assert result['changed'] is False
         assert result['zone_id'] == '42'
         assert result['zone_name'] == 'example.com'
+        assert result['zone_info'] == {
+            'created': '2021-07-09T11:18:37Z',
+            'modified': '2021-07-09T11:18:37Z',
+            'legacy_dns_host': 'string',
+            'legacy_ns': ['string'],
+            'ns': ['string'],
+            'owner': 'Example',
+            'paused': True,
+            'permission': 'string',
+            'project': 'string',
+            'registrar': 'string',
+            'status': 'verified',
+            'ttl': 10800,
+            'verified': '2021-07-09T11:18:37Z',
+            'records_count': 0,
+            'is_secondary_dns': True,
+            'txt_verification': {
+                'name': 'string',
+                'token': 'string',
+            },
+        }
 
     def test_get_id(self, mocker):
         result = self.run_module_success(mocker, hetzner_dns_zone_info, {
@@ -146,3 +167,24 @@ class TestHetznerDNSZoneInfoJSON(BaseTestModule):
         assert result['changed'] is False
         assert result['zone_id'] == '42'
         assert result['zone_name'] == 'example.com'
+        assert result['zone_info'] == {
+            'created': '2021-07-09T11:18:37Z',
+            'modified': '2021-07-09T11:18:37Z',
+            'legacy_dns_host': 'string',
+            'legacy_ns': ['string'],
+            'ns': ['string'],
+            'owner': 'Example',
+            'paused': True,
+            'permission': 'string',
+            'project': 'string',
+            'registrar': 'string',
+            'status': 'verified',
+            'ttl': 10800,
+            'verified': '2021-07-09T11:18:37Z',
+            'records_count': 0,
+            'is_secondary_dns': True,
+            'txt_verification': {
+                'name': 'string',
+                'token': 'string',
+            },
+        }

--- a/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
@@ -307,7 +307,14 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
                     'digest': '012356789ABCDEF0123456789ABCDEF012345678',
                     'flags': 257,
                     'protocol': 3,
-                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                    'public_key':
+                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                        'lfceKgmKwEF=',
                 },
                 {
                     'key_tag': 12345,
@@ -316,7 +323,14 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
                     'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
                     'flags': 257,
                     'protocol': 3,
-                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                    'public_key':
+                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                        'lfceKgmKwEF=',
                 }
             ],
         }

--- a/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
@@ -129,6 +129,10 @@ class TestHosttechDNSZoneInfoWSDL(BaseTestModule):
         assert result['changed'] is False
         assert result['zone_id'] == 42
         assert result['zone_name'] == 'example.com'
+        assert result['zone_info'] == {
+            'email': 'dns@hosttech.eu',
+            'ttl': 10800,
+        }
 
 
 class TestHosttechDNSZoneInfoJSON(BaseTestModule):
@@ -239,6 +243,13 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
         assert result['changed'] is False
         assert result['zone_id'] == 42
         assert result['zone_name'] == 'example.com'
+        assert result['zone_info'] == {
+            'email': 'test@example.com',
+            'ttl': 10800,
+            'dnssec': False,
+            'dnssec_email': None,
+            'ds_records': None,
+        }
 
     def test_get_id(self, mocker):
         result = self.run_module_success(mocker, hosttech_dns_zone_info, {
@@ -257,3 +268,55 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
         assert result['changed'] is False
         assert result['zone_id'] == 42
         assert result['zone_name'] == 'example.com'
+        assert result['zone_info'] == {
+            'email': 'test@example.com',
+            'ttl': 10800,
+            'dnssec': False,
+            'dnssec_email': None,
+            'ds_records': None,
+        }
+
+    def test_get_dnssec(self, mocker):
+        result = self.run_module_success(mocker, hosttech_dns_zone_info, {
+            'hosttech_token': 'foo',
+            'zone_name': 'foo.com',
+            '_ansible_remote_tmp': '/tmp/tmp',
+            '_ansible_keep_remote_files': True,
+        }, [
+            FetchUrlCall('GET', 200)
+            .expect_header('accept', 'application/json')
+            .expect_header('authorization', 'Bearer foo')
+            .expect_url('https://api.ns1.hosttech.eu/api/user/v1/zones', without_query=True)
+            .expect_query_values('query', 'foo.com')
+            .return_header('Content-Type', 'application/json')
+            .result_json(HOSTTECH_JSON_ZONE_LIST_RESULT),
+        ])
+        assert result['changed'] is False
+        assert result['zone_id'] == 43
+        assert result['zone_name'] == 'foo.com'
+        assert result['zone_info'] == {
+            'email': 'test@foo.com',
+            'ttl': 10800,
+            'dnssec': True,
+            'dnssec_email': 'test@foo.com',
+            'ds_records': [
+                {
+                    'key_tag': 12345,
+                    'algorithm': 8,
+                    'digest_type': 1,
+                    'digest': '012356789ABCDEF0123456789ABCDEF012345678',
+                    'flags': 257,
+                    'protocol': 3,
+                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                },
+                {
+                    'key_tag': 12345,
+                    'algorithm': 8,
+                    'digest_type': 2,
+                    'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
+                    'flags': 257,
+                    'protocol': 3,
+                    'public_key': 'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD lfceKgmKwEF=',
+                }
+            ],
+        }


### PR DESCRIPTION
##### SUMMARY
The `*_dns_zone_info` modules should return more information that the APIs provide.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hetzner_dns_zone_info
hosttech_dns_zone_info
