### PR TITLE
Integration test fixes, make sure that hosttech_dns_zone_info always returns same info

### DIFF
--- a/changelogs/fragments/56-tests-fixes.yml
+++ b/changelogs/fragments/56-tests-fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "hosttech_dns_zone_info - make sure that full information is returned both when requesting a zone by ID or by name (https://github.com/ansible-collections/community.dns/pull/56)."

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -280,7 +280,8 @@ class HostTechJSONAPI(ZoneRecordAPI, JSONAPIHelper):
         result = self._list_pagination('user/v1/zones', query=dict(query=name))
         for zone in result:
             if zone['name'] == name:
-                return _create_zone_from_json(zone)
+                # We cannot simply return `_create_zone_from_json(zone)`, since this contains less information!
+                return self.get_zone_by_id(zone['id'])
         return None
 
     def get_zone_by_id(self, id):

--- a/tests/integration/targets/hetzner/tasks/record-sets.yml
+++ b/tests/integration/targets/hetzner/tasks/record-sets.yml
@@ -20,6 +20,33 @@
           - RECORD is failed
           - 'RECORD.msg == "Zone not found"'
 
+    - name: make sure that CNAME record isn't there
+      hetzner_dns_record_set:
+        zone_name: "{{ hetzner_test_zone }}"
+        prefix: dns_ansible_collection
+        type: CNAME
+        state: present
+        value: []
+        hetzner_token: "{{ hetzner_token }}"
+
+    - name: make sure that A record isn't there
+      hetzner_dns_record_set:
+        zone_name: "{{ hetzner_test_zone }}"
+        prefix: dns_ansible_collection
+        type: A
+        state: present
+        value: []
+        hetzner_token: "{{ hetzner_token }}"
+
+    - name: make sure that A record isn't there
+      hetzner_dns_record_set:
+        zone_name: "{{ hetzner_test_zone }}"
+        prefix: website1
+        type: A
+        state: present
+        value: []
+        hetzner_token: "{{ hetzner_token }}"
+
     - name: fetch zone info
       hetzner_dns_zone_info:
         zone_name: "{{ hetzner_test_zone }}"
@@ -303,7 +330,7 @@
     - name: assert 1 A record
       assert:
         that:
-          - RECORD.set.ttl == 3600
+          - RECORD.set.ttl is none
           - RECORD.set.type == 'A'
           - RECORD.set.value | count == 1
           - RECORD.set.value[0] == '127.0.0.2'

--- a/tests/unit/plugins/modules/hosttech.py
+++ b/tests/unit/plugins/modules/hosttech.py
@@ -393,40 +393,6 @@ HOSTTECH_JSON_ZONE_LIST_RESULT = {
             "nameserver": "ns1.hosttech.ch",
             'dnssec': True,
             'dnssec_email': 'test@foo.com',
-            'ds_records': [
-                {
-                    'key_tag': 12345,
-                    'algorithm': 8,
-                    'digest_type': 1,
-                    'digest': '012356789ABCDEF0123456789ABCDEF012345678',
-                    'flags': 257,
-                    'protocol': 3,
-                    'public_key':
-                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
-                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
-                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
-                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
-                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
-                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
-                        'lfceKgmKwEF=',
-                },
-                {
-                    'key_tag': 12345,
-                    'algorithm': 8,
-                    'digest_type': 2,
-                    'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
-                    'flags': 257,
-                    'protocol': 3,
-                    'public_key':
-                        'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
-                        'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
-                        'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
-                        'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
-                        'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
-                        'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
-                        'lfceKgmKwEF=',
-                }
-            ],
         },
     ],
 }
@@ -440,6 +406,53 @@ HOSTTECH_JSON_ZONE_GET_RESULT = {
         "nameserver": "ns1.hosttech.ch",
         "dnssec": False,
         "records": HOSTTECH_JSON_DEFAULT_ENTRIES,
+    }
+}
+
+HOSTTECH_JSON_ZONE_2_GET_RESULT = {
+    "data": {
+        "id": 43,
+        "name": "foo.com",
+        "email": "test@foo.com",
+        "ttl": 10800,
+        "nameserver": "ns1.hosttech.ch",
+        'dnssec': True,
+        'dnssec_email': 'test@foo.com',
+        'ds_records': [
+            {
+                'key_tag': 12345,
+                'algorithm': 8,
+                'digest_type': 1,
+                'digest': '012356789ABCDEF0123456789ABCDEF012345678',
+                'flags': 257,
+                'protocol': 3,
+                'public_key':
+                    'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                    'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                    'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                    'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                    'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                    'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                    'lfceKgmKwEF=',
+            },
+            {
+                'key_tag': 12345,
+                'algorithm': 8,
+                'digest_type': 2,
+                'digest': '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
+                'flags': 257,
+                'protocol': 3,
+                'public_key':
+                    'MuhdzsQdqEGShwjtJDKZZjdKqUSGluFzTTinpuEeIRzLLcgkwgAPKWFa '
+                    'eQntNlmcNDeCziGwpdvhJnvKXEMbFcZwsaDIJuWqERxAQNGABWfPlCLh '
+                    'HQPnbpRPNKipSdBaUhuOubvFvjBpFAwiwSAapRDVsAgKvjXucfXpFfYb '
+                    'pCundbAXBWhbpHVbqgmGoixXzFSwUsGVYLPpBCiDlLJwzjRKYYaoVYge '
+                    'kMtKFYUVnWIKbectWkDFdVqXwkKigCUDiuTTJxOBRJRNzGiDNMWBjYSm '
+                    'bBCAHMaMYaghLbYTwyKXltdHTHwBwtswGNfpnEdSpKFzZJonBZArQfHD '
+                    'lfceKgmKwEF=',
+            }
+        ],
+        "records": [],
     }
 }
 

--- a/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
@@ -23,6 +23,7 @@ from .hosttech import (
     HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
     HOSTTECH_WSDL_ZONE_NOT_FOUND,
     HOSTTECH_JSON_ZONE_GET_RESULT,
+    HOSTTECH_JSON_ZONE_2_GET_RESULT,
     HOSTTECH_JSON_ZONE_LIST_RESULT,
 )
 
@@ -239,6 +240,12 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
             .expect_query_values('query', 'example.com')
             .return_header('Content-Type', 'application/json')
             .result_json(HOSTTECH_JSON_ZONE_LIST_RESULT),
+            FetchUrlCall('GET', 200)
+            .expect_header('accept', 'application/json')
+            .expect_header('authorization', 'Bearer foo')
+            .expect_url('https://api.ns1.hosttech.eu/api/user/v1/zones/42')
+            .return_header('Content-Type', 'application/json')
+            .result_json(HOSTTECH_JSON_ZONE_GET_RESULT),
         ])
         assert result['changed'] is False
         assert result['zone_id'] == 42
@@ -290,6 +297,12 @@ class TestHosttechDNSZoneInfoJSON(BaseTestModule):
             .expect_query_values('query', 'foo.com')
             .return_header('Content-Type', 'application/json')
             .result_json(HOSTTECH_JSON_ZONE_LIST_RESULT),
+            FetchUrlCall('GET', 200)
+            .expect_header('accept', 'application/json')
+            .expect_header('authorization', 'Bearer foo')
+            .expect_url('https://api.ns1.hosttech.eu/api/user/v1/zones/43')
+            .return_header('Content-Type', 'application/json')
+            .result_json(HOSTTECH_JSON_ZONE_2_GET_RESULT),
         ])
         assert result['changed'] is False
         assert result['zone_id'] == 43


### PR DESCRIPTION
##### SUMMARY
While trying out the integration tests for the HostTech and Hetzner modules, I found some problems:
1. The Hetzner tests weren't adapted to no default TTL;
2. The HostTech tests showed that the hosttech_dns_zone_info module returns less information when run for a zone name than for a zone ID. (The zone list API call returns less information than the zone GET API call for DNSSEC enabled domains.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hosttech_dns_zone_info
Hetzner integration tests
