### PR TITLE
Handle API errors for Hetzner's API that don't come with HTTP error status codes

### DIFF
--- a/changelogs/fragments/58-hetzner-api-errors.yml
+++ b/changelogs/fragments/58-hetzner-api-errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "hetzner API code - make sure to also handle errors returned by the API if the HTTP status code indicates success. This sometimes happens for 500 Internal Server Error (https://github.com/ansible-collections/community.dns/pull/58)."

--- a/plugins/module_utils/json_api_helper.py
+++ b/plugins/module_utils/json_api_helper.py
@@ -26,7 +26,8 @@ ERROR_CODES = {
     404: "Not found",
     406: "Not acceptable",
     409: "Conflict",
-    422: "Unprocessable entity"
+    422: "Unprocessable entity",
+    500: "Internal Server Error",
 }
 UNKNOWN_ERROR = "Unknown Error"
 

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set.py
@@ -542,7 +542,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
         print(result['msg'])
         assert result['msg'] == (
             'Error: Expected HTTP status 200, 404 for DELETE https://dns.hetzner.com/api/v1/records/125,'
-            ' but got HTTP status 500 (Unknown Error) with error message "Internal Server Error" (error code 500)'
+            ' but got HTTP status 500 (Internal Server Error) with error message "Internal Server Error" (error code 500)'
         )
 
     def test_absent_bulk(self, mocker):
@@ -636,7 +636,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 200, 404 for DELETE https://dns.hetzner.com/api/v1/records/131,'
-            ' but got HTTP status 500 (Unknown Error) with error message "Internal Server Error" (error code 500)'
+            ' but got HTTP status 500 (Internal Server Error) with error message "Internal Server Error" (error code 500)'
         )
 
     def test_absent_other_value(self, mocker):
@@ -1343,7 +1343,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 200, 422 for PUT https://dns.hetzner.com/api/v1/records/132,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )
 
     def test_change_modify_bulk_errors_2(self, mocker):

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_sets.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_sets.py
@@ -673,7 +673,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
             .expect_query_values('per_page', '100')
             .return_header('Content-Type', 'application/json')
             .result_json(HETZNER_JSON_ZONE_RECORDS_GET_RESULT),
-            FetchUrlCall('POST', 500)
+            FetchUrlCall('POST', 200)
             .expect_header('accept', 'application/json')
             .expect_header('auth-api-token', 'foo')
             .expect_url('https://dns.hetzner.com/api/v1/records')
@@ -684,12 +684,12 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
             .expect_json_value(['name'], '@')
             .expect_json_value(['value'], '128 issue "letsencrypt.org xxx"')
             .return_header('Content-Type', 'application/json')
-            .result_json({'message': 'Internal Server Error'}),
+            .result_json({'record': {}, 'error': {'code': 500, 'message': 'Internal Server Error'}}),
         ])
 
         assert result['msg'] == (
-            'Error: Expected HTTP status 200, 422 for POST https://dns.hetzner.com/api/v1/records,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            'Error: POST https://dns.hetzner.com/api/v1/records resulted in API error 500 (Internal Server Error)'
+            ' with error message "Internal Server Error" (error code 500)'
         )
 
     def test_change_add_two_failed(self, mocker):

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_set.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_set.py
@@ -1043,7 +1043,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 204, 404 for DELETE https://api.ns1.hosttech.eu/api/user/v1/zones/42/records/131,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )
 
     def test_absent_other_value(self, mocker):
@@ -1360,7 +1360,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 201 for POST https://api.ns1.hosttech.eu/api/user/v1/zones/42/records,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )
 
     def test_change_modify_list_fail(self, mocker):
@@ -1779,7 +1779,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 200 for PUT https://api.ns1.hosttech.eu/api/user/v1/zones/42/records/132,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )
 
     def test_change_modify_bulk_errors_create(self, mocker):
@@ -1893,5 +1893,5 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 201 for POST https://api.ns1.hosttech.eu/api/user/v1/zones/42/records,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_sets.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_sets.py
@@ -768,7 +768,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['msg'] == (
             'Error: Expected HTTP status 201 for POST https://api.ns1.hosttech.eu/api/user/v1/zones/42/records,'
-            ' but got HTTP status 500 (Unknown Error) with message "Internal Server Error"'
+            ' but got HTTP status 500 (Internal Server Error) with message "Internal Server Error"'
         )
 
     def test_change_add_one(self, mocker):


### PR DESCRIPTION
##### SUMMARY
While working on #57 I got some Internal Server Errors which disguided as HTTP status code 200, which means OK.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/hetzner/api.py
