### PR TITLE
Improve docs

### DIFF
--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -285,6 +285,10 @@ There are three steps for migrating. Two of these steps must be done on migratio
 
 The `markuman.hetzner_dns collection <https://galaxy.ansible.com/markuman/hetzner_dns>`_ collection provides three modules and one inventory plugin.
 
+.. note::
+
+  When working with TXT records, please look at the ``txt_transformation`` option. By default, the modules and plugins in this collection use **unquoted** values (you do not have to add double quotes and escape double quotes and backslashes), while the modules and plugins in ``markuman.hetzner_dns`` use partially quoted values. You can switch behavior of the ``community.dns`` modules by passing ``txt_transformation=api`` or ``txt_transformation=quoted``.
+
 The markuman.hetzner_dns.record module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -319,6 +323,9 @@ When creating, updating or removing single records, the :ref:`community.dns.hetz
         type: A
         value: 127.0.0.1
         ttl: 60
+        # If type is TXT, you either have to adjust the value you pass,
+        # or keep the following option:
+        txt_transformation: api
 
 When the ``markuman.hetzner_dns.record`` module is in replace mode, it should be replaced by the :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.community.dns.hetzner_dns_record_set_module>`, since then it operates on the *record set* and not just on a single record:
 
@@ -355,6 +362,10 @@ When the ``markuman.hetzner_dns.record`` module is in replace mode, it should be
         # keep the old syntax, in this case:
         #
         #     value: 127.0.0.1
+        #
+        # If type is TXT, you either have to adjust the value you pass,
+        # or keep the following option:
+        txt_transformation: api
 
 When deleting a record, it depends on whether ``value`` is specified or not. If ``value`` is specified, the module is deleting a single DNS record, and the :ref:`community.dns.hetzner_dns_record module <ansible_collections.community.dns.hetzner_dns_record_module>` should be used:
 
@@ -382,6 +393,9 @@ When deleting a record, it depends on whether ``value`` is specified or not. If 
         type: A
         value: 127.0.0.1
         ttl: 60
+        # If type is TXT, you either have to adjust the value you pass,
+        # or keep the following option:
+        txt_transformation: api
 
 When ``value`` is not specified, the ``markuman.hetzner_dns.record`` module will delete all records for this prefix and type. In that case, it operates on a record set and the :ref:`community.dns.hetzner_dns_record_set module <ansible_collections.community.dns.hetzner_dns_record_set_module>` should be used:
 

--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -66,6 +66,10 @@ The module returns both the zone name and zone ID, so this module can be used to
 Working with DNS records
 ------------------------
 
+.. note::
+
+  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the ``txt_transformation`` option which allows to configure this behavior.
+
 Querying DNS records
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -397,7 +397,7 @@ When ``value`` is not specified, the ``markuman.hetzner_dns.record`` module will
         type: A
 
     - name: Deleting a single DNS record with community.dns
-      community.dns.hetzner_dns_record:
+      community.dns.hetzner_dns_record_set:
         zone_name: example.com
         state: absent
         # 'name' is a deprecated alias of 'prefix', so it can be

--- a/docs/docsite/rst/hosttech_guide.rst
+++ b/docs/docsite/rst/hosttech_guide.rst
@@ -89,6 +89,10 @@ The module returns both the zone name and zone ID, so this module can be used to
 Working with DNS records
 ------------------------
 
+.. note::
+
+  By default, TXT record values returned and accepted by the modules and plugins in this collection are unquoted. This means that  you do not have to add double quotes (``"``), and escape double quotes (as ``\"``) and backslashes (as ``\\``). All modules and plugins which work with DNS records support the ``txt_transformation`` option which allows to configure this behavior.
+
 Querying DNS records
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
##### SUMMARY
The migration guide uses a wrong module name, and the guides don't mention `txt_transformation`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
scenario guides
