### PR TITLE
Improving handling of TXT values: forgot changelog fragment and inventory plugin

### DIFF
--- a/changelogs/fragments/57-60-txt_transformation.yml
+++ b/changelogs/fragments/57-60-txt_transformation.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- "Added a ``txt_transformation`` option to all modules and plugins working with DNS records (https://github.com/ansible-collections/community.dns/issues/48, https://github.com/ansible-collections/community.dns/pull/57, https://github.com/ansible-collections/community.dns/pull/60)."
+breaking_changes:
+- "All Hetzner modules and plugins which handle DNS records now work with unquoted TXT values by default. The old behavior can be obtained by setting ``txt_transformation=api`` (https://github.com/ansible-collections/community.dns/issues/48, https://github.com/ansible-collections/community.dns/pull/57, https://github.com/ansible-collections/community.dns/pull/60)."

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -21,7 +21,7 @@ options:
         default: 2
 '''
 
-    TXT_TRANSFORMATION = r'''
+    RECORD_TRANSFORMATION = r'''
 options:
     txt_transformation:
         description:

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -21,6 +21,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.record_type_choices_records_inventory
     - community.dns.hetzner.zone_id_type
     - community.dns.inventory_records
+    - community.dns.options.txt_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -21,7 +21,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.record_type_choices_records_inventory
     - community.dns.hetzner.zone_id_type
     - community.dns.inventory_records
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -21,7 +21,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices_records_inventory
     - community.dns.hosttech.zone_id_type
     - community.dns.inventory_records
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -21,6 +21,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices_records_inventory
     - community.dns.hosttech.zone_id_type
     - community.dns.inventory_records
+    - community.dns.options.txt_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/module_utils/module/record.py
+++ b/plugins/module_utils/module/record.py
@@ -27,7 +27,7 @@ from ansible_collections.community.dns.plugins.module_utils.conversion.converter
 )
 
 from ansible_collections.community.dns.plugins.module_utils.options import (
-    create_txt_transformation_argspec,
+    create_record_transformation_argspec,
 )
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
@@ -68,7 +68,7 @@ def create_module_argument_spec(provider_information):
             ('zone_name', 'zone_id'),
             ('record', 'prefix'),
         ],
-    ).merge(create_txt_transformation_argspec())
+    ).merge(create_record_transformation_argspec())
 
 
 def run_module(module, create_api, provider_information):

--- a/plugins/module_utils/module/record_set.py
+++ b/plugins/module_utils/module/record_set.py
@@ -28,7 +28,7 @@ from ansible_collections.community.dns.plugins.module_utils.conversion.converter
 
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_bulk_operations_argspec,
-    create_txt_transformation_argspec,
+    create_record_transformation_argspec,
 )
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
@@ -80,7 +80,7 @@ def create_module_argument_spec(provider_information):
             ('on_existing', 'keep_and_warn', ['value']),
             ('on_existing', 'keep', ['value']),
         ],
-    ).merge(create_bulk_operations_argspec(provider_information)).merge(create_txt_transformation_argspec())
+    ).merge(create_bulk_operations_argspec(provider_information)).merge(create_record_transformation_argspec())
 
 
 def run_module(module, create_api, provider_information):

--- a/plugins/module_utils/module/record_set_info.py
+++ b/plugins/module_utils/module/record_set_info.py
@@ -27,7 +27,7 @@ from ansible_collections.community.dns.plugins.module_utils.conversion.converter
 )
 
 from ansible_collections.community.dns.plugins.module_utils.options import (
-    create_txt_transformation_argspec,
+    create_record_transformation_argspec,
 )
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
@@ -68,7 +68,7 @@ def create_module_argument_spec(provider_information):
             ('zone_name', 'zone_id'),
             ('record', 'prefix'),
         ],
-    ).merge(create_txt_transformation_argspec())
+    ).merge(create_record_transformation_argspec())
 
 
 def run_module(module, create_api, provider_information):

--- a/plugins/module_utils/module/record_sets.py
+++ b/plugins/module_utils/module/record_sets.py
@@ -28,7 +28,7 @@ from ansible_collections.community.dns.plugins.module_utils.conversion.converter
 
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_bulk_operations_argspec,
-    create_txt_transformation_argspec,
+    create_record_transformation_argspec,
 )
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
@@ -81,7 +81,7 @@ def create_module_argument_spec(provider_information):
         mutually_exclusive=[
             ('zone_name', 'zone_id'),
         ],
-    ).merge(create_bulk_operations_argspec(provider_information)).merge(create_txt_transformation_argspec())
+    ).merge(create_bulk_operations_argspec(provider_information)).merge(create_record_transformation_argspec())
 
 
 def run_module(module, create_api, provider_information):

--- a/plugins/module_utils/options.py
+++ b/plugins/module_utils/options.py
@@ -27,7 +27,7 @@ def create_bulk_operations_argspec(provider_information):
     )
 
 
-def create_txt_transformation_argspec():
+def create_record_transformation_argspec():
     return ArgumentSpec(
         argument_spec=dict(
             txt_transformation=dict(type='str', default='unquoted', choices=['api', 'quoted', 'unquoted']),

--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -29,7 +29,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.record_type_choices
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_set
     - community.dns.options.bulk_operations
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -24,7 +24,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.record_type_choices
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_set_info
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_sets.py
+++ b/plugins/modules/hetzner_dns_record_sets.py
@@ -25,7 +25,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_sets
     - community.dns.options.bulk_operations
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hosttech_dns_record.py
+++ b/plugins/modules/hosttech_dns_record.py
@@ -30,7 +30,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set.py
+++ b/plugins/modules/hosttech_dns_record_set.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set_info
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_sets.py
+++ b/plugins/modules/hosttech_dns_record_sets.py
@@ -25,7 +25,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.record_type_choices_record_sets_module
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_sets
-    - community.dns.options.txt_transformation
+    - community.dns.options.record_transformation
 
 author:
     - Felix Fontein (@felixfontein)


### PR DESCRIPTION
##### SUMMARY
While this should not really be needed in the inventory plugin, I think it's still better to implement transformations there as well in case someone really wants to create hosts from TXT entries. (and possibly when we add other transformations in the future, then the infrastructure is already there...)

Follow-up to #57.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
inventory plugins
