### PR TITLE
Provide access to extra record info

### DIFF
--- a/changelogs/fragments/63-records-extra-info.yml
+++ b/changelogs/fragments/63-records-extra-info.yml
@@ -2,3 +2,4 @@ breaking_changes:
   - The internal record API no longer allows to manage comments explicitly (https://github.com/ansible-collections/community.dns/pull/63).
 minor_changes:
   - The internal record API allows to manage extra data (https://github.com/ansible-collections/community.dns/pull/63).
+  - "*_dns_record - when not using check mode, use actual return data for diff, instead of input data, so that extra data can be shown (https://github.com/ansible-collections/community.dns/pull/63)."

--- a/changelogs/fragments/63-records-extra-info.yml
+++ b/changelogs/fragments/63-records-extra-info.yml
@@ -1,5 +1,6 @@
 breaking_changes:
   - The internal record API no longer allows to manage comments explicitly (https://github.com/ansible-collections/community.dns/pull/63).
+  - The internal bulk record updating helper (``bulk_apply_changes``) now also returns the records that were deleted, created or updated (https://github.com/ansible-collections/community.dns/pull/63).
 minor_changes:
   - The internal record API allows to manage extra data (https://github.com/ansible-collections/community.dns/pull/63).
   - "*_dns_record - when not using check mode, use actual return data for diff, instead of input data, so that extra data can be shown (https://github.com/ansible-collections/community.dns/pull/63)."

--- a/changelogs/fragments/63-records-extra-info.yml
+++ b/changelogs/fragments/63-records-extra-info.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - The internal record API no longer allows to manage comments explicitly (https://github.com/ansible-collections/community.dns/pull/63).

--- a/changelogs/fragments/63-records-extra-info.yml
+++ b/changelogs/fragments/63-records-extra-info.yml
@@ -3,4 +3,4 @@ breaking_changes:
   - The internal bulk record updating helper (``bulk_apply_changes``) now also returns the records that were deleted, created or updated (https://github.com/ansible-collections/community.dns/pull/63).
 minor_changes:
   - The internal record API allows to manage extra data (https://github.com/ansible-collections/community.dns/pull/63).
-  - "*_dns_record - when not using check mode, use actual return data for diff, instead of input data, so that extra data can be shown (https://github.com/ansible-collections/community.dns/pull/63)."
+  - "hetzner_dns_record and hosttech_dns_record - when not using check mode, use actual return data for diff, instead of input data, so that extra data can be shown (https://github.com/ansible-collections/community.dns/pull/63)."

--- a/changelogs/fragments/63-records-extra-info.yml
+++ b/changelogs/fragments/63-records-extra-info.yml
@@ -1,2 +1,4 @@
 breaking_changes:
   - The internal record API no longer allows to manage comments explicitly (https://github.com/ansible-collections/community.dns/pull/63).
+minor_changes:
+  - The internal record API allows to manage extra data (https://github.com/ansible-collections/community.dns/pull/63).

--- a/plugins/module_utils/hetzner/api.py
+++ b/plugins/module_utils/hetzner/api.py
@@ -53,16 +53,19 @@ def _create_zone_from_json(source):
 
 
 def _create_record_from_json(source, type=None, has_id=True):
+    source = dict(source)
     result = DNSRecord()
     if has_id:
-        result.id = source['id']
-    result.type = source.get('type', type)
-    result.ttl = source.get('ttl')
-    name = source.get('name')
+        result.id = source.pop('id')
+    result.type = source.pop('type', type)
+    result.ttl = source.pop('ttl', None)
+    name = source.pop('name', None)
     if name == '@':
         name = None
     result.prefix = name
-    result.target = source['value']
+    result.target = source.pop('value')
+    source.pop('zone_id', None)
+    result.extra.update(source)
     return result
 
 

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -35,7 +35,6 @@ def _create_record_from_json(source, type=None):
     result.id = source['id']
     result.type = source.get('type', type)
     result.ttl = int(source['ttl']) if source['ttl'] is not None else None
-    result.comment = source['comment']
 
     name = source.get('name')
     target = None
@@ -98,7 +97,7 @@ def _create_zone_with_records_from_json(source, prefix=NOT_PROVIDED, record_type
 def _record_to_json(record, include_id=False, include_type=True):
     result = {
         'ttl': record.ttl,
-        'comment': record.comment or '',
+        'comment': '',
     }
     if include_type:
         result['type'] = record.type

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -31,42 +31,46 @@ from ansible_collections.community.dns.plugins.module_utils.zone_record_api impo
 
 
 def _create_record_from_json(source, type=None):
+    source = dict(source)
     result = DNSRecord()
-    result.id = source['id']
-    result.type = source.get('type', type)
-    result.ttl = int(source['ttl']) if source['ttl'] is not None else None
+    result.id = source.pop('id')
+    result.type = source.pop('type', type)
+    ttl = source.pop('ttl')
+    result.ttl = int(ttl) if ttl is not None else None
+    result.extra['comment'] = source.pop('comment')
 
-    name = source.get('name')
+    name = source.pop('name', None)
     target = None
     if result.type == 'A':
-        target = source['ipv4']
+        target = source.pop('ipv4')
     elif result.type == 'AAAA':
-        target = source['ipv6']
+        target = source.pop('ipv6')
     elif result.type == 'CAA':
-        target = '{0} {1} "{2}"'.format(source['flag'], source['tag'], source['value'])
+        target = '{0} {1} "{2}"'.format(source.pop('flag'), source.pop('tag'), source.pop('value'))
     elif result.type == 'CNAME':
-        target = source['cname']
+        target = source.pop('cname')
     elif result.type == 'MX':
-        name = source['ownername']
-        target = '{0} {1}'.format(source['pref'], source['name'])
+        mx_name, name = name, source.pop('ownername')
+        target = '{0} {1}'.format(source.pop('pref'), mx_name)
     elif result.type == 'NS':
-        name = source['ownername']
-        target = source['targetname']
+        name = source.pop('ownername')
+        target = source.pop('targetname')
     elif result.type == 'PTR':
-        name = ''
-        target = '{0} {1}'.format(source['origin'], source['name'])
+        ptr_name, name = name, ''
+        target = '{0} {1}'.format(source.pop('origin'), ptr_name)
     elif result.type == 'SRV':
-        name = source['service']
-        target = '{0} {1} {2} {3}'.format(source['priority'], source['weight'], source['port'], source['target'])
+        name = source.pop('service')
+        target = '{0} {1} {2} {3}'.format(source.pop('priority'), source.pop('weight'), source.pop('port'), source.pop('target'))
     elif result.type == 'TXT':
-        target = source['text']
+        target = source.pop('text')
     elif result.type == 'TLSA':
-        target = source['text']
+        target = source.pop('text')
     else:
         raise DNSAPIError('Cannot parse unknown record type: {0}'.format(result.type))
 
     result.prefix = name or None  # API returns '', we want None
     result.target = target
+    result.extra.update(source)
     return result
 
 
@@ -97,7 +101,7 @@ def _create_zone_with_records_from_json(source, prefix=NOT_PROVIDED, record_type
 def _record_to_json(record, include_id=False, include_type=True):
     result = {
         'ttl': record.ttl,
-        'comment': '',
+        'comment': record.extra.get('comment') or '',
     }
     if include_type:
         result['type'] = record.type

--- a/plugins/module_utils/hosttech/wsdl_api.py
+++ b/plugins/module_utils/hosttech/wsdl_api.py
@@ -35,15 +35,18 @@ from ansible_collections.community.dns.plugins.module_utils.zone_record_api impo
 
 
 def _create_record_from_encoding(source, type=None):
+    source = dict(source)
     result = DNSRecord()
-    result.id = source['id']
-    result.type = source.get('type', type)
-    result.prefix = source.get('prefix')
-    result.ttl = int(source['ttl']) if source['ttl'] is not None else None
+    result.id = source.pop('id')
+    result.type = source.pop('type', type)
+    result.prefix = source.pop('prefix', None)
+    ttl = source.pop('ttl')
+    result.ttl = int(ttl) if ttl is not None else None
     if result.type in ('PTR', 'MX'):
-        result.target = '{0} {1}'.format(source.get('priority'), source.get('target'))
+        result.target = '{0} {1}'.format(source.pop('priority'), source.pop('target'))
     else:
-        result.target = source.get('target')
+        result.target = source.pop('target')
+    result.extra.update(source)
     return result
 
 

--- a/plugins/module_utils/module/record.py
+++ b/plugins/module_utils/module/record.py
@@ -150,7 +150,8 @@ def run_module(module, create_api, provider_information):
                 record.target = value_in
                 api_record = record_converter.clone_to_api(record)
                 if not module.check_mode:
-                    api.add_record(zone_id, api_record)
+                    new_api_record = api.add_record(zone_id, api_record)
+                    record = record_converter.clone_from_api(new_api_record)
                 after = record
                 changed = True
             elif not exact_match:
@@ -159,7 +160,8 @@ def run_module(module, create_api, provider_information):
                 record.ttl = ttl_in
                 api_record = record_converter.clone_to_api(record)
                 if not module.check_mode:
-                    api.update_record(zone_id, api_record)
+                    new_api_record = api.update_record(zone_id, api_record)
+                    record = record_converter.clone_from_api(new_api_record)
                 after = record
                 changed = True
         else:

--- a/plugins/module_utils/module/record_sets.py
+++ b/plugins/module_utils/module/record_sets.py
@@ -199,18 +199,20 @@ def run_module(module, create_api, provider_information):
                 for record in record_set:
                     new_record_sets[key].remove(record)
 
-        # Apply changes
+        # Compose result
         result = dict(
             changed=False,
             zone_id=zone_id,
         )
+
+        # Apply changes
         if to_create or to_delete or to_change:
             records_to_delete = record_converter.clone_multiple_to_api(to_delete)
             records_to_change = record_converter.clone_multiple_to_api(to_change)
             records_to_create = record_converter.clone_multiple_to_api(to_create)
             result['changed'] = True
             if not module.check_mode:
-                dummy, errors = bulk_apply_changes(
+                dummy, errors, success = bulk_apply_changes(
                     api,
                     zone_id=zone_id,
                     records_to_delete=records_to_delete,

--- a/plugins/module_utils/record.py
+++ b/plugins/module_utils/record.py
@@ -32,7 +32,6 @@ class DNSRecord(object):
         self.prefix = None
         self.target = None
         self.ttl = 86400  # 24 * 60 * 60
-        self.comment = None
 
     def clone(self):
         result = DNSRecord()
@@ -41,7 +40,6 @@ class DNSRecord(object):
         result.prefix = self.prefix
         result.target = self.target
         result.ttl = self.ttl
-        result.comment = self.comment
         return result
 
     def __str__(self):
@@ -55,8 +53,6 @@ class DNSRecord(object):
             data.append('prefix: (none)')
         data.append('target: "{0}"'.format(self.target))
         data.append('ttl: {0}'.format(format_ttl(self.ttl)))
-        if self.comment is not None:
-            data.append('comment: {0}'.format(self.comment))
         return 'DNSRecord(' + ', '.join(data) + ')'
 
     def __repr__(self):

--- a/plugins/module_utils/record.py
+++ b/plugins/module_utils/record.py
@@ -32,6 +32,7 @@ class DNSRecord(object):
         self.prefix = None
         self.target = None
         self.ttl = 86400  # 24 * 60 * 60
+        self.extra = {}
 
     def clone(self):
         result = DNSRecord()
@@ -40,6 +41,7 @@ class DNSRecord(object):
         result.prefix = self.prefix
         result.target = self.target
         result.ttl = self.ttl
+        result.extra = dict(self.extra)
         return result
 
     def __str__(self):
@@ -53,6 +55,8 @@ class DNSRecord(object):
             data.append('prefix: (none)')
         data.append('target: "{0}"'.format(self.target))
         data.append('ttl: {0}'.format(format_ttl(self.ttl)))
+        if self.extra:
+            data.append('extra: {0}'.format(self.extra))
         return 'DNSRecord(' + ', '.join(data) + ')'
 
     def __repr__(self):
@@ -86,6 +90,7 @@ def format_record_for_output(record, record_name, prefix=None, record_converter=
         'type': record.type,
         'ttl': record.ttl,
         'value': record.target,
+        'extra': record.extra,
     }
     if record_converter:
         entry['value'] = record_converter.process_value_to_user(entry['type'], entry['value'])

--- a/tests/unit/plugins/module_utils/hosttech/test_json_api.py
+++ b/tests/unit/plugins/module_utils/hosttech/test_json_api.py
@@ -46,7 +46,6 @@ def test_AAAA():
     assert record.prefix == 'www'
     assert record.target == '2001:db8:1234::1'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -65,7 +64,6 @@ def test_A():
     assert record.prefix == 'www'
     assert record.target == '1.2.3.4'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -86,7 +84,6 @@ def test_CAA():
     assert record.prefix is None
     assert record.target == '0 issue "letsencrypt.org"'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
     # We also accept versions without quotes:
@@ -114,7 +111,6 @@ def test_CNAME():
     assert record.prefix == 'www'
     assert record.target == 'site.example.com'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -134,7 +130,6 @@ def test_MX():
     assert record.prefix is None
     assert record.target == '10 mail.example.com'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
     record.target = 'mail.example.com'
@@ -165,7 +160,6 @@ def test_NS():
     assert record.prefix == 'sub'
     assert record.target == 'ns1.example.com'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -184,7 +178,6 @@ def test_PTR():
     assert record.prefix is None
     assert record.target == '4.3.2.1 smtp.example.com'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
     record.target = 'smtp.example.com'
@@ -211,7 +204,6 @@ def test_SRV():
     assert record.prefix == '_autodiscover._tcp'
     assert record.target == '0 1 443 exchange.example.com'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
     record.target = '1 443 exchange.example.com'
@@ -254,7 +246,6 @@ def test_TXT():
     assert record.prefix is None
     assert record.target == 'v=spf1 ip4:1.2.3.4/32 -all'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -273,7 +264,6 @@ def test_TLSA():
     assert record.prefix is None
     assert record.target == '0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971'
     assert record.ttl == 3600
-    assert record.comment == 'my first record'
     assert _record_to_json(record, include_id=True) == data
 
 

--- a/tests/unit/plugins/module_utils/hosttech/test_json_api.py
+++ b/tests/unit/plugins/module_utils/hosttech/test_json_api.py
@@ -46,6 +46,9 @@ def test_AAAA():
     assert record.prefix == 'www'
     assert record.target == '2001:db8:1234::1'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -64,6 +67,9 @@ def test_A():
     assert record.prefix == 'www'
     assert record.target == '1.2.3.4'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -84,6 +90,9 @@ def test_CAA():
     assert record.prefix is None
     assert record.target == '0 issue "letsencrypt.org"'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
     # We also accept versions without quotes:
@@ -111,6 +120,9 @@ def test_CNAME():
     assert record.prefix == 'www'
     assert record.target == 'site.example.com'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -130,6 +142,9 @@ def test_MX():
     assert record.prefix is None
     assert record.target == '10 mail.example.com'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
     record.target = 'mail.example.com'
@@ -160,6 +175,9 @@ def test_NS():
     assert record.prefix == 'sub'
     assert record.target == 'ns1.example.com'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -178,6 +196,9 @@ def test_PTR():
     assert record.prefix is None
     assert record.target == '4.3.2.1 smtp.example.com'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
     record.target = 'smtp.example.com'
@@ -204,6 +225,9 @@ def test_SRV():
     assert record.prefix == '_autodiscover._tcp'
     assert record.target == '0 1 443 exchange.example.com'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
     record.target = '1 443 exchange.example.com'
@@ -246,6 +270,9 @@ def test_TXT():
     assert record.prefix is None
     assert record.target == 'v=spf1 ip4:1.2.3.4/32 -all'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 
@@ -264,6 +291,9 @@ def test_TLSA():
     assert record.prefix is None
     assert record.target == '0 0 1 d2abde240d7cd3ee6b4b28c54df034b97983a1d16e8a410e4561cb106618e971'
     assert record.ttl == 3600
+    assert record.extra == {
+        'comment': 'my first record',
+    }
     assert _record_to_json(record, include_id=True) == data
 
 

--- a/tests/unit/plugins/module_utils/test_record.py
+++ b/tests/unit/plugins/module_utils/test_record.py
@@ -37,6 +37,7 @@ def test_format_records_for_output():
     A1.type = 'A'
     A1.ttl = 300
     A1.target = '1.2.3.4'
+    A1.extra['foo'] = 'bar'
     A2 = DNSRecord()
     A2.type = 'A'
     A2.ttl = 300
@@ -137,5 +138,6 @@ def test_record_str_repr():
     A2.type = 'A'
     A2.ttl = 1
     A2.target = ''
-    assert str(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)'
-    assert repr(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)'
+    A2.extra['foo'] = 'bar'
+    assert str(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, extra: {\'foo\': \'bar\'})'
+    assert repr(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, extra: {\'foo\': \'bar\'})'

--- a/tests/unit/plugins/module_utils/test_record.py
+++ b/tests/unit/plugins/module_utils/test_record.py
@@ -137,6 +137,5 @@ def test_record_str_repr():
     A2.type = 'A'
     A2.ttl = 1
     A2.target = ''
-    A2.comment = 'test'
-    assert str(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)'
-    assert repr(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)'
+    assert str(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)'
+    assert repr(A2) == 'DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)'

--- a/tests/unit/plugins/module_utils/test_zone.py
+++ b/tests/unit/plugins/module_utils/test_zone.py
@@ -46,15 +46,16 @@ def test_zone_with_records_str_repr():
     A2.type = 'A'
     A2.ttl = 1
     A2.target = ''
+    A2.extra['foo'] = 23
     ZZ1 = DNSZoneWithRecords(Z1, [A1])
     ZZ2 = DNSZoneWithRecords(Z2, [A1, A2])
     assert str(ZZ1) == '(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
     assert repr(ZZ1) == 'DNSZoneWithRecords(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
     assert str(ZZ2) == (
         '(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
-        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)])'
+        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, extra: {\'foo\': 23})])'
     )
     assert repr(ZZ2) == (
         'DNSZoneWithRecords(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
-        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)])'
+        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, extra: {\'foo\': 23})])'
     )

--- a/tests/unit/plugins/module_utils/test_zone.py
+++ b/tests/unit/plugins/module_utils/test_zone.py
@@ -46,16 +46,15 @@ def test_zone_with_records_str_repr():
     A2.type = 'A'
     A2.ttl = 1
     A2.target = ''
-    A2.comment = 'test'
     ZZ1 = DNSZoneWithRecords(Z1, [A1])
     ZZ2 = DNSZoneWithRecords(Z2, [A1, A2])
     assert str(ZZ1) == '(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
     assert repr(ZZ1) == 'DNSZoneWithRecords(DNSZone(name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m)])'
     assert str(ZZ2) == (
         '(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
-        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)])'
+        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)])'
     )
     assert repr(ZZ2) == (
         'DNSZoneWithRecords(DNSZone(id: 42, name: foo, info: {}), [DNSRecord(type: A, prefix: (none), target: "1.2.3.4", ttl: 5m),'
-        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s, comment: test)])'
+        ' DNSRecord(id: 23, type: A, prefix: "bar", target: "", ttl: 1s)])'
     )

--- a/tests/unit/plugins/modules/test_hetzner_dns_record.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record.py
@@ -219,6 +219,10 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
             'type': 'MX',
             'ttl': 3600,
             'value': '10 example.com',
+            'extra': {
+                'created': '2021-07-09T11:18:37Z',
+                'modified': '2021-07-09T11:18:37Z',
+            },
         }
         assert result['diff']['before'] == result['diff']['after']
 
@@ -498,6 +502,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
             'type': 'CAA',
             'ttl': 3600,
             'value': '0 issue "letsencrypt.org"',
+            'extra': {},
         }
 
     def test_change_add_one(self, mocker):

--- a/tests/unit/plugins/modules/test_hetzner_dns_record.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record.py
@@ -514,6 +514,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
             'type': 'CAA',
             'ttl': 3600,
             'value': '128 issue "letsencrypt.org xxx"',
+            '_ansible_diff': True,
             '_ansible_remote_tmp': '/tmp/tmp',
             '_ansible_keep_remote_files': True,
         }, [
@@ -552,12 +553,29 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
                     'value': '128 issue "letsencrypt.org xxx"',
                     'ttl': 3600,
                     'zone_id': '42',
+                    'created': '2021-07-09T11:18:37Z',
+                    'modified': '2021-07-09T11:18:37Z',
                 },
             }),
         ])
 
         assert result['changed'] is True
         assert result['zone_id'] == '42'
+        assert 'diff' in result
+        assert 'before' in result['diff']
+        assert 'after' in result['diff']
+        assert result['diff']['before'] == {}
+        assert result['diff']['after'] == {
+            'prefix': '',
+            'record': 'example.com',
+            'type': 'CAA',
+            'ttl': 3600,
+            'value': '128 issue "letsencrypt.org xxx"',
+            'extra': {
+                'created': '2021-07-09T11:18:37Z',
+                'modified': '2021-07-09T11:18:37Z',
+            },
+        }
 
     def test_change_add_one_prefix(self, mocker):
         result = self.run_module_success(mocker, hetzner_dns_record, {

--- a/tests/unit/plugins/modules/test_hosttech_dns_record.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record.py
@@ -512,6 +512,9 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
             'type': 'MX',
             'ttl': 3600,
             'value': '10 example.com',
+            'extra': {
+                'comment': '',
+            },
         }
         assert result['diff']['before'] == result['diff']['after']
 
@@ -763,6 +766,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
             'type': 'CAA',
             'ttl': 3600,
             'value': '0 issue "letsencrypt.org"',
+            'extra': {},
         }
 
     def test_change_add_one(self, mocker):

--- a/tests/unit/plugins/modules/test_hosttech_dns_record.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record.py
@@ -778,6 +778,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
             'type': 'CAA',
             'ttl': 3600,
             'value': '128 issue "letsencrypt.org xxx"',
+            '_ansible_diff': True,
             '_ansible_remote_tmp': '/tmp/tmp',
             '_ansible_keep_remote_files': True,
         }, [
@@ -823,6 +824,20 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
 
         assert result['changed'] is True
         assert result['zone_id'] == 42
+        assert 'diff' in result
+        assert 'before' in result['diff']
+        assert 'after' in result['diff']
+        assert result['diff']['before'] == {}
+        assert result['diff']['after'] == {
+            'prefix': '',
+            'record': 'example.com',
+            'type': 'CAA',
+            'ttl': 3600,
+            'value': '128 issue "letsencrypt.org xxx"',
+            'extra': {
+                'comment': '',
+            },
+        }
 
     def test_change_add_one_prefix(self, mocker):
         result = self.run_module_success(mocker, hosttech_dns_record, {


### PR DESCRIPTION
##### SUMMARY
Background: https://github.com/markuman/hetzner_dns/issues/6#issuecomment-914481052

Right now this only affects diff mode for *_dns_record, since the diff mode for *_dns_record_set and *_dns_record_sets aggregates multiple records, where including the extra only works well if we know how to aggregate its contents.

I'm currently thinking of adding a *_dns_record_info module to retrieve individual records (and not record sets).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
DNS record API
*_dns_record
