### PR TITLE
wait_for_txt: fix empty nameserver bug

### DIFF
--- a/changelogs/fragments/65-wait_for_txt-ns.yml
+++ b/changelogs/fragments/65-wait_for_txt-ns.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "wait_for_txt - resolving nameservers sometimes resulted in an empty list, yielding wrong results (https://github.com/ansible-collections/community.dns/pull/64)."

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -86,7 +86,7 @@ class ResolveDirectlyFromNameServers(object):
                 return None, cname
             if rrset.rdtype == dns.rdatatype.NS:
                 new_nameservers.extend(str(ns_record.target) for ns_record in rrset)
-        return sorted(set(new_nameservers)), cname
+        return sorted(set(new_nameservers)) if new_nameservers else None, cname
 
     def _lookup_address(self, target):
         result = self.cache.get((target, 'addr'))


### PR DESCRIPTION
##### SUMMARY
Apparently on systems using systemd-resolvd (like Ubuntu 20.04), the code to find nameservers resulted in an empty list. This caused wait_for_txt to exit directly without waiting (since the conditions were satisfied for all nameservers).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
wait_for_txt
