### PR TITLE
Update CI matrix to include ansible-core's stable-2.12 branch

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -28,6 +28,7 @@ jobs:
           - stable-2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -74,6 +75,7 @@ jobs:
           - stable-2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
           - devel
 
     steps:
@@ -131,9 +133,8 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
           - stable-2.11
+          - stable-2.12
           - devel
         python:
           - 2.6
@@ -145,18 +146,20 @@ jobs:
           - 3.9
           - "3.10"
         exclude:
-          # Because ansible-test doesn't support python3.9 for Ansible 2.9
-          - ansible: stable-2.9
-            python: 3.9
-          # Because ansible-test doesn't support python3.10 for Ansible 2.9
-          - ansible: stable-2.9
-            python: "3.10"
-          # Because ansible-test doesn't support python3.10 for ansible-base 2.10
-          - ansible: stable-2.10
-            python: "3.10"
           # Because ansible-test doesn't support python3.10 for ansible-core 2.11
           - ansible: stable-2.11
             python: "3.10"
+        include:
+          # 2.9
+          - ansible: stable-2.9
+            python: 2.7
+          - ansible: stable-2.9
+            python: 3.5
+          - ansible: stable-2.9
+            python: 3.6
+          # 2.10
+          - ansible: stable-2.10
+            python: 3.5
 
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Update CI matrix to include ansible-core's stable-2.12 branch. Reduces testing for older Ansible versions to avoid increasing CI load (too much).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
