### PR TITLE
Fix compatibility to fetch_url change in ansible-core devel

### DIFF
--- a/changelogs/fragments/fetch_url-devel.yml
+++ b/changelogs/fragments/fetch_url-devel.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "HTTP API module utils - fix usage of ``fetch_url`` with changes in latest ansible-core ``devel`` branch (https://github.com/ansible-collections/community.dns/pull/73)."


### PR DESCRIPTION
##### SUMMARY
There was a breaking change in ansible-core's devel branch (see https://github.com/ansible/ansible/pull/76314 for details). This makes this collection's code work with the latest version, and all older ansible-core/ansible-base/Ansible 2.9 versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
HTTP API helper module utils