### PR TITLE
Fix typo in hosttech_password option description

### DIFF
--- a/plugins/doc_fragments/hosttech.py
+++ b/plugins/doc_fragments/hosttech.py
@@ -24,7 +24,7 @@ options:
     hosttech_password:
         description:
           - The password for the Hosttech API user.
-          - If provided, I(hosttech_password) must also be provided.
+          - If provided, I(hosttech_username) must also be provided.
           - Mutually exclusive with I(hosttech_token).
         type: str
     hosttech_token:


### PR DESCRIPTION
##### SUMMARY

Fix a typo in the `hosttech_password` option description, where it says one also needs to provide `hosttech_password` instead of `hosttech_username`.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
hosttech

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
