### PR TITLE
CI: lxml 4.8.0 doesn't work with Python 3.11, and 4.9.0 hasn't been released yet

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -4,5 +4,4 @@ importlib ; python_version < '2.7'
 dnspython
 
 lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
-lxml ; python_version >= '2.7' and python_version < '3.11'
-https://github.com/lxml/lxml/archive/master.tar.gz ; python_version >= '3.11' # TODO: remove once lxml 4.9.0 is released
+lxml ; python_version >= '2.7' and python_version < '3.11' # TODO: remove limitation once lxml 4.9.0 is released

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -4,4 +4,5 @@ importlib ; python_version < '2.7'
 dnspython
 
 lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
-lxml ; python_version >= '2.7'
+lxml ; python_version >= '2.7' and python_version < '3.11'
+https://github.com/lxml/lxml/archive/master.tar.gz ; python_version >= '3.11' # TODO: remove once lxml 4.9.0 is released


### PR DESCRIPTION
##### SUMMARY
The Python 3.11 unit tests currently fail: https://github.com/ansible-collections/community.dns/runs/6501315889?check_suite_focus=true

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
