### PR TITLE
wait_for_txt: improve error messages

### DIFF
--- a/changelogs/fragments/105-wait_for_txt-improve-error-msg.yml
+++ b/changelogs/fragments/105-wait_for_txt-improve-error-msg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "wait_for_txt - improve error messages so that in case of SERVFAILs or other DNS errors it is clear which record was queried from which DNS server (https://github.com/ansible-collections/community.dns/pull/105)."

--- a/tests/unit/plugins/module_utils/test_resolver.py
+++ b/tests/unit/plugins/module_utils/test_resolver.py
@@ -436,7 +436,7 @@ def test_error_servfail():
                 with pytest.raises(ResolverError) as exc:
                     resolver = ResolveDirectlyFromNameServers()
                     resolver.resolve_nameservers('example.com')
-                assert exc.value.args[0] == 'Error SERVFAIL'
+                assert exc.value.args[0] == 'Error SERVFAIL while querying 1.1.1.1 with query get NS for "com."'
 
 
 def test_no_response():

--- a/tests/unit/plugins/modules/test_wait_for_txt.py
+++ b/tests/unit/plugins/modules/test_wait_for_txt.py
@@ -1192,7 +1192,7 @@ class TestWaitForTXT(ModuleTestCase):
                             wait_for_txt.main()
 
         print(exc.value.args[0])
-        assert exc.value.args[0]['msg'] == 'Unexpected resolving error: Error SERVFAIL'
+        assert exc.value.args[0]['msg'] == 'Unexpected resolving error: Error SERVFAIL while querying 1.1.1.1 with query get NS for "com."'
         assert exc.value.args[0]['completed'] == 0
         assert len(exc.value.args[0]['records']) == 1
         assert exc.value.args[0]['records'][0]['name'] == 'www.example.com'


### PR DESCRIPTION
##### SUMMARY
Improve error messages for DNS errors so that it is clear which query was made to which server when that error was obtained.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
wait_for_txt
