### PR TITLE
Add `hetzner` and `hosttech` action groups; use attributes to document module capabilities; support check mode for wait_for_txt

### DIFF
--- a/changelogs/fragments/action_groups.yml
+++ b/changelogs/fragments/action_groups.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Added a ``community.dns.hetzner`` module defaults group / action group. Use with ``group/community.dns.hetzner`` to provide options for all Hetzner DNS modules (https://github.com/ansible-collections/community.dns/pull/119)."
+  - "Added a ``community.dns.hosttech`` module defaults group / action group. Use with ``group/community.dns.hosttech`` to provide options for all Hosttech DNS modules (https://github.com/ansible-collections/community.dns/pull/119)."

--- a/changelogs/fragments/wait_for_txt-check_mode.yml
+++ b/changelogs/fragments/wait_for_txt-check_mode.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "wait_for_txt - the module now supports check mode. The only practical change in behavior is that in check mode, the module is now executed instead of skipped. Since the module does not change anything, it should have been marked as supporting check mode since it has been added (https://github.com/ansible-collections/community.dns/pull/119)."
+  - "wait_for_txt - the module now supports check mode. The only practical change in behavior is that in check mode, the module is now executed instead of skipped. Since the module does not change anything, it should have been marked as supporting check mode since it was originally added (https://github.com/ansible-collections/community.dns/pull/119)."

--- a/changelogs/fragments/wait_for_txt-check_mode.yml
+++ b/changelogs/fragments/wait_for_txt-check_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "wait_for_txt - the module now supports check mode. The only practical change in behavior is that in check mode, the module is now executed instead of skipped. Since the module does not change anything, it should have been marked as supporting check mode since it has been added (https://github.com/ansible-collections/community.dns/pull/119)."

--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -43,6 +43,37 @@ To use Hetzner's API, you need to create an API token. You can manage API tokens
 
 In the examples in this guide, we will leave the authentication options away. Please note that you can set them globally with ``module_defaults`` (see :ref:`module_defaults`) or with an environment variable for the user and machine where the modules are run on.
 
+Using the ``community.dns.hetzner`` module defaults group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid having to specify common parameters for all Hetzner DNS modules in every task, you can use the ``community.dns.hetzner`` module defaults group:
+
+.. code-block:: yaml+jinja
+
+    ---
+    - name: Hetzner DNS
+      hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/community.dns.hetzner
+          hetzner_token: '{{ token }}'
+      tasks:
+        - name: Query zone information
+          community.dns.hetzner_dns_zone_info:
+            zone_name: example.com
+          register: result
+
+        - name: Set A records for www.example.com
+          community.dns.hetzner_dns_record_set:
+            state: present
+            zone_name: example.com
+            type: A
+            prefix: www
+            value:
+              - 192.168.0.1
+
+Here all two tasks will use the options set for the module defaults group.
+
 Working with DNS zones
 ----------------------
 

--- a/docs/docsite/rst/hosttech_guide.rst
+++ b/docs/docsite/rst/hosttech_guide.rst
@@ -66,6 +66,38 @@ You also need to install the `lxml Python module <https://pypi.org/project/lxml/
 
 In the examples in this guide, we will leave the authentication options away. Please note that you can set them globally with ``module_defaults`` (see :ref:`module_defaults`).
 
+Using the ``community.dns.hosttech`` module defaults group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid having to specify common parameters for all Hosttech DNS modules in every task, you can use the ``community.dns.hosttech`` module defaults group:
+
+.. code-block:: yaml+jinja
+
+    ---
+    - name: Hosttech DNS
+      hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/community.dns.hosttech
+          hosttech_username: '{{ username }}'
+          hosttech_password: '{{ password }}'
+      tasks:
+        - name: Query zone information
+          community.dns.hosttech_dns_zone_info:
+            zone_name: example.com
+          register: result
+
+        - name: Set A records for www.example.com
+          community.dns.hosttech_dns_record_set:
+            state: present
+            zone_name: example.com
+            type: A
+            prefix: www
+            value:
+              - 192.168.0.1
+
+Here all two tasks will use the options set for the module defaults group.
+
 Working with DNS zones
 ----------------------
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,6 +4,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 requires_ansible: '>=2.9.10'
+action_groups:
+  hetzner:
+    - hetzner_dns_record_info
+    - hetzner_dns_record
+    - hetzner_dns_record_set_info
+    - hetzner_dns_record_set
+    - hetzner_dns_record_sets
+    - hetzner_dns_zone_info
+  hosttech:
+    - hosttech_dns_record_info
+    - hosttech_dns_record
+    - hosttech_dns_record_set_info
+    - hosttech_dns_record_set
+    - hosttech_dns_record_sets
+    - hosttech_dns_records   # deprecated redirect
+    - hosttech_dns_zone_info
 plugin_routing:
   modules:
     hosttech_dns_records:

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -18,9 +18,6 @@ attributes:
       description: Can run in C(check_mode) and return changed status prediction without modifying target.
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
-    platform:
-      description: Target OS/families that can be operated against.
-      support: N/A
 '''
 
     ACTIONGROUP_HETZNER = r'''
@@ -65,7 +62,7 @@ attributes:
 options: {}
 attributes:
     safe_file_operations:
-      description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
+      description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption.
 '''
 
     FLOW = r'''

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Standard documentation fragment
+    DOCUMENTATION = r'''
+attributes:
+    check_mode:
+      description: Can run in C(check_mode) and return changed status prediction without modifying target.
+    diff_mode:
+      description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+    platform:
+      description: Target OS/families that can be operated against.
+      support: N/A
+'''
+
+    ACTIONGROUP_HETZNER = r'''
+attributes:
+    action_group:
+      description: Use C(group/community.dns.hetzner) in C(module_defaults) to set defaults for this module.
+      support: full
+      membership:
+        - community.dns.hetzner
+'''
+
+    ACTIONGROUP_HOSTTECH = r'''
+attributes:
+    action_group:
+      description: Use C(group/community.dns.hosttech) in C(module_defaults) to set defaults for this module.
+      support: full
+      membership:
+        - community.dns.hosttech
+'''
+
+    CONN = r'''
+attributes:
+    become:
+      description: Is usable alongside C(become) keywords.
+    connection:
+      description: Uses the target's configured connection information to execute code on it.
+    delegation:
+      description: Can be used in conjunction with C(delegate_to) and related keywords.
+'''
+
+    FACTS = r'''
+attributes:
+    facts:
+      description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
+'''
+
+    FILES = r'''
+attributes:
+    safe_file_operations:
+      description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
+'''
+
+    FLOW = r'''
+attributes:
+    action:
+      description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller.
+    async:
+      description: Supports being used with the C(async) keyword.
+'''

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -12,6 +12,7 @@ class ModuleDocFragment(object):
 
     # Standard documentation fragment
     DOCUMENTATION = r'''
+options: {}
 attributes:
     check_mode:
       description: Can run in C(check_mode) and return changed status prediction without modifying target.
@@ -23,6 +24,7 @@ attributes:
 '''
 
     ACTIONGROUP_HETZNER = r'''
+options: {}
 attributes:
     action_group:
       description: Use C(group/community.dns.hetzner) in C(module_defaults) to set defaults for this module.
@@ -32,6 +34,7 @@ attributes:
 '''
 
     ACTIONGROUP_HOSTTECH = r'''
+options: {}
 attributes:
     action_group:
       description: Use C(group/community.dns.hosttech) in C(module_defaults) to set defaults for this module.
@@ -41,6 +44,7 @@ attributes:
 '''
 
     CONN = r'''
+options: {}
 attributes:
     become:
       description: Is usable alongside C(become) keywords.
@@ -51,18 +55,21 @@ attributes:
 '''
 
     FACTS = r'''
+options: {}
 attributes:
     facts:
       description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
 '''
 
     FILES = r'''
+options: {}
 attributes:
     safe_file_operations:
       description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption.
 '''
 
     FLOW = r'''
+options: {}
 attributes:
     action:
       description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller.

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -20,6 +20,20 @@ attributes:
       description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
 '''
 
+    # Should be used together with the standard fragment
+    INFO_MODULE = r'''
+options: {}
+attributes:
+    check_mode:
+      support: full
+      details:
+        - This action does not modify state.
+    diff_mode:
+      support: N/A
+      details:
+        - This action does not modify state.
+'''
+
     ACTIONGROUP_HETZNER = r'''
 options: {}
 attributes:
@@ -56,6 +70,22 @@ options: {}
 attributes:
     facts:
       description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
+'''
+
+    # Should be used together with the standard fragment and the FACTS fragment
+    FACTS_MODULE = r'''
+options: {}
+attributes:
+    check_mode:
+      support: full
+      details:
+        - This action does not modify state.
+    diff_mode:
+      support: N/A
+      details:
+        - This action does not modify state.
+    facts:
+      support: full
 '''
 
     FILES = r'''

--- a/plugins/doc_fragments/module_record.py
+++ b/plugins/doc_fragments/module_record.py
@@ -66,7 +66,4 @@ options:
             not be deleted.
         required: true
         type: str
-
-notes:
-    - "Supports C(check_mode) and C(--diff)."
 '''

--- a/plugins/doc_fragments/module_record_info.py
+++ b/plugins/doc_fragments/module_record_info.py
@@ -53,7 +53,4 @@ options:
           - The type of DNS record to retrieve.
           - Required if I(what) is C(single_record).
         type: str
-
-notes:
-    - "Supports C(check_mode)."
 '''

--- a/plugins/doc_fragments/module_record_set.py
+++ b/plugins/doc_fragments/module_record_set.py
@@ -87,7 +87,4 @@ options:
           - keep_and_fail
           - keep_and_warn
           - keep
-
-notes:
-    - "Supports C(check_mode) and C(--diff)."
 '''

--- a/plugins/doc_fragments/module_record_set_info.py
+++ b/plugins/doc_fragments/module_record_set_info.py
@@ -55,7 +55,4 @@ options:
           - The type of DNS record to retrieve.
           - Required if I(what) is C(single_record).
         type: str
-
-notes:
-    - "Supports C(check_mode)."
 '''

--- a/plugins/doc_fragments/module_record_sets.py
+++ b/plugins/doc_fragments/module_record_sets.py
@@ -85,7 +85,4 @@ options:
                     without having to know their current value.
                 type: bool
                 default: false
-
-notes:
-    - "Supports C(check_mode) and C(--diff)."
 '''

--- a/plugins/doc_fragments/module_zone_info.py
+++ b/plugins/doc_fragments/module_zone_info.py
@@ -25,7 +25,4 @@ options:
           - The ID of the DNS zone to query.
           - Exactly one of I(zone_name) and I(zone_id) must be specified.
         version_added: 0.2.0
-
-notes:
-    - "Supports C(check_mode)."
 '''

--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -31,11 +31,16 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -31,6 +31,11 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -26,6 +26,11 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_info
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -26,11 +26,16 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_info
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -28,18 +28,11 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -34,8 +34,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -28,11 +28,16 @@ extends_documentation_fragment:
     - community.dns.module_record_set
     - community.dns.options.bulk_operations
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -28,6 +28,11 @@ extends_documentation_fragment:
     - community.dns.module_record_set
     - community.dns.options.bulk_operations
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 options:
     prefix:

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -26,11 +26,16 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_set_info
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -28,18 +28,11 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -34,8 +34,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -26,6 +26,11 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.module_record_set_info
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_sets.py
+++ b/plugins/modules/hetzner_dns_record_sets.py
@@ -27,6 +27,11 @@ extends_documentation_fragment:
     - community.dns.module_record_sets
     - community.dns.options.bulk_operations
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_record_sets.py
+++ b/plugins/modules/hetzner_dns_record_sets.py
@@ -27,11 +27,16 @@ extends_documentation_fragment:
     - community.dns.module_record_sets
     - community.dns.options.bulk_operations
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -24,6 +24,11 @@ extends_documentation_fragment:
     - community.dns.hetzner
     - community.dns.hetzner.zone_id_type
     - community.dns.module_zone_info
+    - community.dns.attributes.actiongroup_hetzner
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -26,18 +26,11 @@ extends_documentation_fragment:
     - community.dns.module_zone_info
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -24,11 +24,16 @@ extends_documentation_fragment:
     - community.dns.hetzner
     - community.dns.hetzner.zone_id_type
     - community.dns.module_zone_info
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hetzner
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -32,8 +32,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>

--- a/plugins/modules/hosttech_dns_record.py
+++ b/plugins/modules/hosttech_dns_record.py
@@ -32,11 +32,16 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record.py
+++ b/plugins/modules/hosttech_dns_record.py
@@ -32,6 +32,11 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -26,11 +26,16 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_info
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -26,6 +26,11 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_info
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -28,18 +28,11 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -34,8 +34,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set.py
+++ b/plugins/modules/hosttech_dns_record_set.py
@@ -28,11 +28,16 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set.py
+++ b/plugins/modules/hosttech_dns_record_set.py
@@ -28,6 +28,11 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -28,11 +28,16 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set_info
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -28,6 +28,11 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_set_info
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -36,8 +36,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -30,18 +30,11 @@ extends_documentation_fragment:
     - community.dns.options.record_transformation
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_sets.py
+++ b/plugins/modules/hosttech_dns_record_sets.py
@@ -27,11 +27,16 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_sets
     - community.dns.options.record_transformation
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_record_sets.py
+++ b/plugins/modules/hosttech_dns_record_sets.py
@@ -27,6 +27,11 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.module_record_sets
     - community.dns.options.record_transformation
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -24,6 +24,11 @@ extends_documentation_fragment:
     - community.dns.hosttech
     - community.dns.hosttech.zone_id_type
     - community.dns.module_zone_info
+    - community.dns.attributes.actiongroup_hosttech
+
+attributes:
+    action_group:
+        version_added: 2.4.0
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -26,18 +26,11 @@ extends_documentation_fragment:
     - community.dns.module_zone_info
     - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
+    - community.dns.attributes.info_module
 
 attributes:
     action_group:
         version_added: 2.4.0
-    check_mode:
-        support: full
-        details:
-            - This action does not modify state.
-    diff_mode:
-        support: N/A
-        details:
-            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -24,11 +24,16 @@ extends_documentation_fragment:
     - community.dns.hosttech
     - community.dns.hosttech.zone_id_type
     - community.dns.module_zone_info
+    - community.dns.attributes
     - community.dns.attributes.actiongroup_hosttech
 
 attributes:
     action_group:
         version_added: 2.4.0
+    check_mode:
+        support: full
+    diff_mode:
+        support: full
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -32,8 +32,12 @@ attributes:
         version_added: 2.4.0
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 
 author:
     - Felix Fontein (@felixfontein)

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -20,7 +20,8 @@ extends_documentation_fragment:
     - community.dns.attributes
 attributes:
     check_mode:
-        support: none
+        support: full
+        version_added: 2.4.0
     diff_mode:
         support: full
 author:
@@ -247,6 +248,7 @@ def main():
             max_sleep=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
         ),
+        supports_check_mode=True,
     )
     assert_requirements_present(module)
 

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -21,9 +21,13 @@ extends_documentation_fragment:
 attributes:
     check_mode:
         support: full
+        details:
+            - This action does not modify state.
         version_added: 2.4.0
     diff_mode:
-        support: full
+        support: N/A
+        details:
+            - This action does not modify state.
 author:
     - Felix Fontein (@felixfontein)
 options:

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -16,6 +16,13 @@ short_description: Wait for TXT entries to be available on all authoritative nam
 version_added: 0.1.0
 description:
     - Wait for TXT entries with specific values to show up on B(all) authoritative nameservers for the DNS name.
+extends_documentation_fragment:
+    - community.dns.attributes
+attributes:
+    check_mode:
+        support: none
+    diff_mode:
+        support: full
 author:
     - Felix Fontein (@felixfontein)
 options:


### PR DESCRIPTION
##### SUMMARY
Add `community.dns.hetzner` and `community.dns.hosttech` action groups.

Uses attributes to document module capabilities.

The `wait_for_txt` module was not maked as `supports_check_mode=True`. Since it does not make any change, this is clearly an oversight and is now fixed.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
all modules
