### PR TITLE
Switch CI from ubuntu-latest to ubuntu-20.04 to avoid problems with ansible-test from ansible-core 2.12, 2.13, 2.14

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -36,7 +36,7 @@ jobs:
           - stable-2.13
           - stable-2.14
           - devel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Perform sanity testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -45,7 +45,7 @@ jobs:
           testing-type: sanity
 
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
@@ -73,7 +73,7 @@ jobs:
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: I (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
##### SUMMARY
This is necessary until https://github.com/ansible/ansible/pull/78550 has been backported to stable-2.12, stable-2.13, and stable-2.14.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
GHA CI
