### PR TITLE
Add txt_character_encoding option. Prepare to switch to decimal escape sequences in community.dns 3.0.0

### DIFF
--- a/changelogs/fragments/txt-quoting.yml
+++ b/changelogs/fragments/txt-quoting.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "various modules and inventory plugins - add new option ``txt_character_encoding`` which allows whether numeric escape sequences are interpreted as octals or decimals when ``txt_transformation=quoted`` (https://github.com/ansible-collections/community.dns/pull/134)."
+deprecated_features:
+  - "The default of the newly added option ``txt_character_encoding`` will change from ``octal`` to ``decimal`` in community.dns 3.0.0. The new default will be compatible with `RFC 1035 <https://www.ietf.org/rfc/rfc1035.txt>`__ (https://github.com/ansible-collections/community.dns/pull/134)."

--- a/changelogs/fragments/txt-quoting.yml
+++ b/changelogs/fragments/txt-quoting.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - "various modules and inventory plugins - add new option ``txt_character_encoding`` which allows whether numeric escape sequences are interpreted as octals or decimals when ``txt_transformation=quoted`` (https://github.com/ansible-collections/community.dns/pull/134)."
+  - "various modules and inventory plugins - add new option ``txt_character_encoding`` which controls whether numeric escape sequences are interpreted as octals or decimals when ``txt_transformation=quoted`` (https://github.com/ansible-collections/community.dns/pull/134)."
 deprecated_features:
   - "The default of the newly added option ``txt_character_encoding`` will change from ``octal`` to ``decimal`` in community.dns 3.0.0. The new default will be compatible with `RFC 1035 <https://www.ietf.org/rfc/rfc1035.txt>`__ (https://github.com/ansible-collections/community.dns/pull/134)."

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -51,4 +51,14 @@ options:
             - quoted
             - unquoted
         default: unquoted
+    txt_character_encoding:
+        description:
+            - Whether to treat numeric escape sequences (C(\xyz)) as octal or decimal numbers.
+            - The current default is C(octal) which is deprecated. It will change to C(decimal) in
+              community.dns 3.0.0. The value C(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
+        type: str
+        choices:
+            - decimal
+            - octal
+        version_added: 2.5.0
 '''

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -54,6 +54,7 @@ options:
     txt_character_encoding:
         description:
             - Whether to treat numeric escape sequences (C(\xyz)) as octal or decimal numbers.
+              This is only used when I(txt_transformation=quoted).
             - The current default is C(octal) which is deprecated. It will change to C(decimal) in
               community.dns 3.0.0. The value C(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
         type: str

--- a/plugins/module_utils/conversion/txt.py
+++ b/plugins/module_utils/conversion/txt.py
@@ -80,8 +80,9 @@ def decode_txt_value(value, character_encoding=_SENTINEL):
     """
     if character_encoding is _SENTINEL:
         warnings.warn(
-            'The default value of the encode_txt_value parameter character_encoding is deprecated.'
-            ' Set explicitly to "octal" for the old behavior, or set to "decimal" for the new and correct behavior.'
+            'The default value of the decode_txt_value parameter character_encoding is deprecated.'
+            ' Set explicitly to "octal" for the old behavior, or set to "decimal" for the new and correct behavior.',
+            DeprecationWarning,
         )
         character_encoding = 'octal'
     if character_encoding not in ('octal', 'decimal'):
@@ -145,7 +146,10 @@ def encode_txt_value(value, always_quote=False, use_character_encoding=_SENTINEL
     If use_character_encoding (default: True) is set to False, do not use octal encoding.
     """
     if use_octal is not _SENTINEL:
-        warnings.warn('The encode_txt_value parameter use_octal is deprecated. Use use_character_encoding instead.')
+        warnings.warn(
+            'The encode_txt_value parameter use_octal is deprecated. Use use_character_encoding instead.',
+            DeprecationWarning,
+        )
         if use_character_encoding is not _SENTINEL:
             raise ValueError('Cannot use both use_character_encoding and use_octal. Use only use_character_encoding!')
         use_character_encoding = use_octal
@@ -154,7 +158,8 @@ def encode_txt_value(value, always_quote=False, use_character_encoding=_SENTINEL
     if character_encoding is _SENTINEL:
         warnings.warn(
             'The default value of the encode_txt_value parameter character_encoding is deprecated.'
-            ' Set explicitly to "octal" for the old behavior, or set to "decimal" for the new and correct behavior.'
+            ' Set explicitly to "octal" for the old behavior, or set to "decimal" for the new and correct behavior.',
+            DeprecationWarning,
         )
         character_encoding = 'octal'
     if character_encoding not in ('octal', 'decimal'):

--- a/plugins/module_utils/hetzner/api.py
+++ b/plugins/module_utils/hetzner/api.py
@@ -392,9 +392,9 @@ class HetznerProviderInformation(ProviderInformation):
         Returns one of the following strings:
         * 'decoded' - the API works with unencoded values
         * 'encoded' - the API works with encoded values
-        * 'encoded-no-octal' - the API works with encoded values, but without octal encoding
+        * 'encoded-no-char-encoding' - the API works with encoded values, but without character encoding
         """
-        return 'encoded-no-octal'
+        return 'encoded-no-char-encoding'
 
 
 def create_hetzner_provider_information():

--- a/plugins/module_utils/hosttech/api.py
+++ b/plugins/module_utils/hosttech/api.py
@@ -78,7 +78,7 @@ class HosttechProviderInformation(ProviderInformation):
         Returns one of the following strings:
         * 'decoded' - the API works with unencoded values
         * 'encoded' - the API works with encoded values
-        * 'encoded-no-octal' - the API works with encoded values, but without octal encoding
+        * 'encoded-no-char-encoding' - the API works with encoded values, but without character encoding
         """
         return 'decoded'
 

--- a/plugins/module_utils/module/record.py
+++ b/plugins/module_utils/module/record.py
@@ -75,6 +75,7 @@ def create_module_argument_spec(provider_information):
 def run_module(module, create_api, provider_information):
     option_provider = ModuleOptionProvider(module)
     record_converter = RecordConverter(provider_information, option_provider)
+    record_converter.emit_deprecations(module.deprecate)
 
     record_in = normalize_dns_name(module.params.get('record'))
     prefix_in = module.params.get('prefix')

--- a/plugins/module_utils/module/record_info.py
+++ b/plugins/module_utils/module/record_info.py
@@ -75,6 +75,7 @@ def create_module_argument_spec(provider_information):
 def run_module(module, create_api, provider_information):
     option_provider = ModuleOptionProvider(module)
     record_converter = RecordConverter(provider_information, option_provider)
+    record_converter.emit_deprecations(module.deprecate)
 
     filter_record_type = NOT_PROVIDED
     filter_prefix = NOT_PROVIDED

--- a/plugins/module_utils/module/record_set.py
+++ b/plugins/module_utils/module/record_set.py
@@ -87,6 +87,7 @@ def create_module_argument_spec(provider_information):
 def run_module(module, create_api, provider_information):
     option_provider = ModuleOptionProvider(module)
     record_converter = RecordConverter(provider_information, option_provider)
+    record_converter.emit_deprecations(module.deprecate)
 
     record_in = normalize_dns_name(module.params.get('record'))
     prefix_in = module.params.get('prefix')

--- a/plugins/module_utils/module/record_set_info.py
+++ b/plugins/module_utils/module/record_set_info.py
@@ -75,6 +75,7 @@ def create_module_argument_spec(provider_information):
 def run_module(module, create_api, provider_information):
     option_provider = ModuleOptionProvider(module)
     record_converter = RecordConverter(provider_information, option_provider)
+    record_converter.emit_deprecations(module.deprecate)
 
     filter_record_type = NOT_PROVIDED
     filter_prefix = NOT_PROVIDED

--- a/plugins/module_utils/module/record_sets.py
+++ b/plugins/module_utils/module/record_sets.py
@@ -88,6 +88,7 @@ def create_module_argument_spec(provider_information):
 def run_module(module, create_api, provider_information):
     option_provider = ModuleOptionProvider(module)
     record_converter = RecordConverter(provider_information, option_provider)
+    record_converter.emit_deprecations(module.deprecate)
 
     try:
         # Create API

--- a/plugins/module_utils/options.py
+++ b/plugins/module_utils/options.py
@@ -32,5 +32,6 @@ def create_record_transformation_argspec():
     return ArgumentSpec(
         argument_spec=dict(
             txt_transformation=dict(type='str', default='unquoted', choices=['api', 'quoted', 'unquoted']),
+            txt_character_encoding=dict(type='str', choices=['decimal', 'octal']),
         ),
     )

--- a/plugins/module_utils/provider.py
+++ b/plugins/module_utils/provider.py
@@ -91,5 +91,19 @@ class ProviderInformation(object):
         Returns one of the following strings:
         * 'decoded' - the API works with unencoded values
         * 'encoded' - the API works with encoded values
-        * 'encoded-no-octal' - the API works with encoded values, but without octal encoding
+        * 'encoded-no-char-encoding' - the API works with encoded values, but without character encoding
         """
+
+    def txt_character_encoding(self):
+        """
+        Return how the API handles escape sequences in TXT records.
+
+        Returns one of the following strings:
+        * 'octal' - the API works with octal escape sequences
+        * 'decimal' - the API works with decimal escape sequences
+
+        This return value is only used if txt_record_handling returns 'encoded'.
+
+        WARNING: the default return value will change to 'decimal' for community.dns 3.0.0!
+        """
+        return 'octal'

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -72,6 +72,7 @@ class RecordsInventoryModule(BaseInventoryPlugin):
         try:
             self.setup_api()
             self.record_converter = RecordConverter(self.provider_information, self)
+            self.record_converter.emit_deprecations(display.deprecated)
 
             zone_name = self.get_option('zone_name')
             if self.templar.is_template(zone_name):

--- a/tests/unit/plugins/module_utils/conversion/test_converter.py
+++ b/tests/unit/plugins/module_utils/conversion/test_converter.py
@@ -31,8 +31,8 @@ from ..helper import (
 
 def test_user_api():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='decoded'),
-        CustomProvideOptions({'txt_transformation': 'api'}))
+        CustomProviderInformation(txt_record_handling='decoded', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'api', 'txt_character_encoding': 'decimal'}))
     assert converter.process_value_from_user('TXT', u'"xyz \\') == u'"xyz \\'
     assert converter.process_values_from_user('TXT', [u'"xyz \\']) == [u'"xyz \\']
     assert converter.process_value_to_user('TXT', u'"xyz \\') == u'"xyz \\'
@@ -60,31 +60,31 @@ def test_user_api():
 
 def test_user_quoted():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='decoded'),
-        CustomProvideOptions({'txt_transformation': 'quoted'}))
-    assert converter.process_value_from_user('TXT', u'hëllo " w\\303\\266rld"') == u'hëllo wörld'
-    assert converter.process_values_from_user('TXT', [u'hëllo " w\\303\\266rld"']) == [u'hëllo wörld']
-    assert converter.process_value_to_user('TXT', u'hello wörld') == u'"hello w\\303\\266rld"'
-    assert converter.process_values_to_user('TXT', [u'hello wörld']) == [u'"hello w\\303\\266rld"']
+        CustomProviderInformation(txt_record_handling='decoded', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'quoted', 'txt_character_encoding': 'decimal'}))
+    assert converter.process_value_from_user('TXT', u'hëllo " w\\195\\182rld"') == u'hëllo wörld'
+    assert converter.process_values_from_user('TXT', [u'hëllo " w\\195\\182rld"']) == [u'hëllo wörld']
+    assert converter.process_value_to_user('TXT', u'hello wörld') == u'"hello w\\195\\182rld"'
+    assert converter.process_values_to_user('TXT', [u'hello wörld']) == [u'"hello w\\195\\182rld"']
 
     record = DNSRecord()
     record.type = 'TXT'
 
-    record.target = u'hëllo " w\\303\\266rld"'
+    record.target = u'hëllo " w\\195\\182rld"'
     converter.process_from_user(record)
     assert record.target == u'hëllo wörld'
 
-    record.target = u'hëllo " w\\303\\266rld"'
+    record.target = u'hëllo " w\\195\\182rld"'
     converter.process_multiple_from_user([record])
     assert record.target == u'hëllo wörld'
 
     record.target = u'hello wörld'
     converter.process_to_user(record)
-    assert record.target == u'"hello w\\303\\266rld"'
+    assert record.target == u'"hello w\\195\\182rld"'
 
     record.target = u'hello wörld'
     converter.process_multiple_to_user([record])
-    assert record.target == u'"hello w\\303\\266rld"'
+    assert record.target == u'"hello w\\195\\182rld"'
 
     record.target = u'"a\\o'
     with pytest.raises(DNSConversionError) as exc:
@@ -97,8 +97,8 @@ def test_user_quoted():
 
 def test_user_unquoted():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='decoded'),
-        CustomProvideOptions({'txt_transformation': 'unquoted'}))
+        CustomProviderInformation(txt_record_handling='decoded', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'unquoted', 'txt_character_encoding': 'decimal'}))
     assert converter.process_value_from_user('TXT', u'hello "wörl\\d"') == u'hello "wörl\\d"'
     assert converter.process_values_from_user('TXT', [u'hello "wörl\\d"']) == [u'hello "wörl\\d"']
     assert converter.process_value_to_user('TXT', u'hello "wörl\\d"') == u'hello "wörl\\d"'
@@ -126,8 +126,8 @@ def test_user_unquoted():
 
 def test_api_decoded():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='decoded'),
-        CustomProvideOptions({'txt_transformation': 'unquoted'}))
+        CustomProviderInformation(txt_record_handling='decoded', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'unquoted', 'txt_character_encoding': 'decimal'}))
     record = DNSRecord()
     record.type = 'TXT'
 
@@ -168,25 +168,25 @@ def test_api_decoded():
 
 def test_api_encoded():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='encoded'),
-        CustomProvideOptions({'txt_transformation': 'unquoted'}))
+        CustomProviderInformation(txt_record_handling='encoded', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'unquoted', 'txt_character_encoding': 'decimal'}))
     record = DNSRecord()
     record.type = 'TXT'
 
-    record.target = u'xyz " " \\\\\\303\\266'
+    record.target = u'xyz " " \\\\\\195\\182'
     record_2 = converter.clone_from_api(record)
     assert record is not record_2
-    assert record.target == u'xyz " " \\\\\\303\\266'
+    assert record.target == u'xyz " " \\\\\\195\\182'
     print(record_2.target)
     assert record_2.target == u'xyz \\ö'
     converter.process_from_api(record)
     assert record.target == u'xyz \\ö'
 
-    record.target = u'xyz " " \\\\\\303\\266'
+    record.target = u'xyz " " \\\\\\195\\182'
     records = converter.clone_multiple_from_api([record])
     assert len(records) == 1
     assert record is not records[0]
-    assert record.target == u'xyz " " \\\\\\303\\266'
+    assert record.target == u'xyz " " \\\\\\195\\182'
     assert records[0].target == u'xyz \\ö'
     converter.process_multiple_from_api([record])
     assert record.target == u'xyz \\ö'
@@ -195,18 +195,18 @@ def test_api_encoded():
     record_2 = converter.clone_to_api(record)
     assert record is not record_2
     assert record.target == u'xyz \\ö'
-    assert record_2.target == u'"xyz \\\\\\303\\266"'
+    assert record_2.target == u'"xyz \\\\\\195\\182"'
     converter.process_to_api(record)
-    assert record.target == u'"xyz \\\\\\303\\266"'
+    assert record.target == u'"xyz \\\\\\195\\182"'
 
     record.target = u'xyz \\ö'
     records = converter.clone_multiple_to_api([record])
     assert len(records) == 1
     assert record is not records[0]
     assert record.target == u'xyz \\ö'
-    assert records[0].target == u'"xyz \\\\\\303\\266"'
+    assert records[0].target == u'"xyz \\\\\\195\\182"'
     converter.process_multiple_to_api([record])
-    assert record.target == u'"xyz \\\\\\303\\266"'
+    assert record.target == u'"xyz \\\\\\195\\182"'
 
     record.target = u'"a'
     with pytest.raises(DNSConversionError) as exc:
@@ -219,25 +219,25 @@ def test_api_encoded():
 
 def test_api_encoded_no_octal():
     converter = RecordConverter(
-        CustomProviderInformation(txt_record_handling='encoded-no-octal'),
-        CustomProvideOptions({'txt_transformation': 'unquoted'}))
+        CustomProviderInformation(txt_record_handling='encoded-no-octal', txt_character_encoding='decimal'),
+        CustomProvideOptions({'txt_transformation': 'unquoted', 'txt_character_encoding': 'decimal'}))
     record = DNSRecord()
     record.type = 'TXT'
 
-    record.target = u'xyz " " \\\\\\303\\266'
+    record.target = u'xyz " " \\\\\\195\\182'
     record_2 = converter.clone_from_api(record)
     assert record is not record_2
-    assert record.target == u'xyz " " \\\\\\303\\266'
+    assert record.target == u'xyz " " \\\\\\195\\182'
     print(record_2.target)
     assert record_2.target == u'xyz \\ö'
     converter.process_from_api(record)
     assert record.target == u'xyz \\ö'
 
-    record.target = u'xyz " " \\\\\\303\\266'
+    record.target = u'xyz " " \\\\\\195\\182'
     records = converter.clone_multiple_from_api([record])
     assert len(records) == 1
     assert record is not records[0]
-    assert record.target == u'xyz " " \\\\\\303\\266'
+    assert record.target == u'xyz " " \\\\\\195\\182'
     assert records[0].target == u'xyz \\ö'
     converter.process_multiple_from_api([record])
     assert record.target == u'xyz \\ö'

--- a/tests/unit/plugins/module_utils/conversion/test_txt.py
+++ b/tests/unit/plugins/module_utils/conversion/test_txt.py
@@ -24,17 +24,19 @@ from ansible_collections.community.dns.plugins.module_utils.conversion.txt impor
 
 
 TEST_DECODE = [
-    (r'', u''),
-    (r'"" "" ""', u''),
-    (r'   ""     ""  ', u''),
-    (r'\040\041', u' !'),
-    (r'"\040" \041 ""', u' !'),
+    (r'', 'decimal', u''),
+    (r'"" "" ""', 'decimal', u''),
+    (r'   ""     ""  ', 'decimal', u''),
+    (r'\032\033', 'decimal', u' !'),
+    (r'"\032" \033 ""', 'decimal', u' !'),
+    (r'\040\041', 'octal', u' !'),
+    (r'"\040" \041 ""', 'octal', u' !'),
 ]
 
 
-@pytest.mark.parametrize("encoded, decoded", TEST_DECODE)
-def test_decode(encoded, decoded):
-    decoded_ = decode_txt_value(encoded)
+@pytest.mark.parametrize("encoded, character_encoding, decoded", TEST_DECODE)
+def test_decode(encoded, character_encoding, decoded):
+    decoded_ = decode_txt_value(encoded, character_encoding=character_encoding)
     print(repr(decoded_), repr(decoded))
     assert decoded_ == decoded
 
@@ -42,7 +44,7 @@ def test_decode(encoded, decoded):
 TEST_GET_UTF8_LENGTH = [
     # See https://en.wikipedia.org/wiki/UTF-8#Examples
     (0xC2, 2),  # first byte of UTF-8 encoding of U+0024
-    (0o303, 2),  # first byte of UTF-8 encoding of ä
+    (0xC3, 2),  # first byte of UTF-8 encoding of ä
     (0xE0, 3),  # first byte of UTF-8 encoding of U+0939
     (0xE2, 3),  # first byte of UTF-8 encoding of U+20AC
     (0xED, 3),  # first byte of UTF-8 encoding of U+D55C
@@ -60,18 +62,18 @@ def test_get_utf8_length(letter_code, length):
 
 
 TEST_ENCODE_DECODE = [
-    (u'', u'""', False, True),
-    (u'', u'""', True, True),
-    (u'Hi', u'Hi', False, True),
-    (u'Hi', u'"Hi"', True, True),
-    (u'"\\', u'\\\"\\\\', False, True),
-    (u'"\\', u'"\\"\\\\"', True, True),
-    (u'ä', u'ä', False, False),
-    (u'ä', u'"ä"', True, False),
-    (u'ä', u'\\303\\244', False, True),
-    (u'ä', u'"\\303\\244"', True, True),
-    (u'a b', u'"a b"', False, True),
-    (u'a b', u'"a b"', True, True),
+    (u'', u'""', False, True, 'decimal'),
+    (u'', u'""', True, True, 'decimal'),
+    (u'Hi', u'Hi', False, True, 'decimal'),
+    (u'Hi', u'"Hi"', True, True, 'decimal'),
+    (u'"\\', u'\\\"\\\\', False, True, 'decimal'),
+    (u'"\\', u'"\\"\\\\"', True, True, 'decimal'),
+    (u'ä', u'ä', False, False, 'decimal'),
+    (u'ä', u'"ä"', True, False, 'decimal'),
+    (u'ä', u'\\195\\164', False, True, 'decimal'),
+    (u'ä', u'"\\195\\164"', True, True, 'decimal'),
+    (u'a b', u'"a b"', False, True, 'decimal'),
+    (u'a b', u'"a b"', True, True, 'decimal'),
     (
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
@@ -81,7 +83,7 @@ TEST_ENCODE_DECODE = [
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
         u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefg hijklmnopqrstu'
         u'vwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-        False, True
+        False, True, 'decimal'
     ),
     (
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
@@ -92,7 +94,7 @@ TEST_ENCODE_DECODE = [
         u'BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012'
         u'3456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefg" "hijklmnopqr'
         u'stuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"',
-        True, True
+        True, True, 'decimal'
     ),
     (
         u'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzA'
@@ -103,7 +105,7 @@ TEST_ENCODE_DECODE = [
         u'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01'
         u'23456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" ghijklmnopqr'
         u'stuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-        False, True
+        False, True, 'decimal'
     ),
     (
         u'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzA'
@@ -114,7 +116,7 @@ TEST_ENCODE_DECODE = [
         u'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01'
         u'23456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" "ghijklmnopq'
         u'rstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"',
-        True, True
+        True, True, 'decimal'
     ),
     (
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
@@ -123,7 +125,7 @@ TEST_ENCODE_DECODE = [
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
         u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefg',
-        False, True
+        False, True, 'decimal'
     ),
     (
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
@@ -132,17 +134,17 @@ TEST_ENCODE_DECODE = [
         u'"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzA'
         u'BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012'
         u'3456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefg"',
-        True, True
+        True, True, 'decimal'
     ),
     (
-        # Avoid splitting up an octal sequence into multiple TXT strings
+        # Avoid splitting up an decimal sequence into multiple TXT strings
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
         u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789aä',
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
-        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789a\\303 \\244',
-        False, True
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789a\\195 \\164',
+        False, True, 'decimal'
     ),
     (
         # Avoid splitting up a UTF-8 character into multiple TXT strings
@@ -152,37 +154,62 @@ TEST_ENCODE_DECODE = [
         u'"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzA'
         u'BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012'
         u'3456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" "ä"',
-        True, False
+        True, False, 'decimal'
+    ),
+    (
+        # Avoid splitting up an octal sequence into multiple TXT strings
+        u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
+        u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789aä',
+        u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
+        u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789a\\303 \\244',
+        False, True, 'octal'
+    ),
+    (
+        # Avoid splitting up a UTF-8 character into multiple TXT strings
+        u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
+        u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefä',
+        u'"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzA'
+        u'BCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012'
+        u'3456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef" "ä"',
+        True, False, 'octal'
     ),
 ]
 
 
-@pytest.mark.parametrize("decoded, encoded, always_quote, use_octal", TEST_ENCODE_DECODE)
-def test_encode_decode(decoded, encoded, always_quote, use_octal):
-    decoded_ = decode_txt_value(encoded)
+@pytest.mark.parametrize("decoded, encoded, always_quote, use_character_encoding, character_encoding", TEST_ENCODE_DECODE)
+def test_encode_decode(decoded, encoded, always_quote, use_character_encoding, character_encoding):
+    decoded_ = decode_txt_value(encoded, character_encoding=character_encoding)
     print(repr(decoded_), repr(decoded))
     assert decoded_ == decoded
-    encoded_ = encode_txt_value(decoded, always_quote=always_quote, use_octal=use_octal)
+    encoded_ = encode_txt_value(decoded, always_quote=always_quote, use_character_encoding=use_character_encoding, character_encoding=character_encoding)
     print(repr(encoded_), repr(encoded))
     assert encoded_ == encoded
 
 
 TEST_DECODE_ERROR = [
-    (u'\\', 'Unexpected backslash at end of string'),
-    (u'\\a', 'A backslash must not be followed by "a" (index 2)'),
-    (u'\\0', 'The octal sequence at the end requires 2 more digit(s)'),
-    (u'\\00', 'The octal sequence at the end requires 1 more digit(s)'),
-    (u'\\0a', 'The octal sequence at the end requires 1 more digit(s)'),
-    (u'\\0a0', 'The second letter of the octal sequence at index 3 is not an octal digit, but "a"'),
-    (u'\\00a', 'The third letter of the octal sequence at index 4 is not an octal digit, but "a"'),
-    (u'a"b', 'Unexpected double quotation mark inside an unquoted block at position 2'),
-    (u'"', 'Missing double quotation mark at the end of value'),
+    (u'\\', 'decimal', 'Unexpected backslash at end of string'),
+    (u'\\a', 'decimal', 'A backslash must not be followed by "a" (index 2)'),
+    (u'\\0', 'decimal', 'The decimal sequence at the end requires 2 more digit(s)'),
+    (u'\\00', 'decimal', 'The decimal sequence at the end requires 1 more digit(s)'),
+    (u'\\0a', 'decimal', 'The decimal sequence at the end requires 1 more digit(s)'),
+    (u'\\0a0', 'decimal', 'The second letter of the decimal sequence at index 3 is not a decimal digit, but "a"'),
+    (u'\\00a', 'decimal', 'The third letter of the decimal sequence at index 4 is not a decimal digit, but "a"'),
+    (u'\\0', 'octal', 'The octal sequence at the end requires 2 more digit(s)'),
+    (u'\\00', 'octal', 'The octal sequence at the end requires 1 more digit(s)'),
+    (u'\\0a', 'octal', 'The octal sequence at the end requires 1 more digit(s)'),
+    (u'\\0a0', 'octal', 'The second letter of the octal sequence at index 3 is not a octal digit, but "a"'),
+    (u'\\00a', 'octal', 'The third letter of the octal sequence at index 4 is not a octal digit, but "a"'),
+    (u'a"b', 'decimal', 'Unexpected double quotation mark inside an unquoted block at position 2'),
+    (u'"', 'decimal', 'Missing double quotation mark at the end of value'),
 ]
 
 
-@pytest.mark.parametrize("encoded, error", TEST_DECODE_ERROR)
-def test_decode_error(encoded, error):
+@pytest.mark.parametrize("encoded, character_encoding, error", TEST_DECODE_ERROR)
+def test_decode_error(encoded, character_encoding, error):
     with pytest.raises(DNSConversionError) as exc:
-        decode_txt_value(encoded)
+        decode_txt_value(encoded, character_encoding=character_encoding)
     print(exc.value.error_message)
     assert exc.value.error_message == error

--- a/tests/unit/plugins/module_utils/helper.py
+++ b/tests/unit/plugins/module_utils/helper.py
@@ -15,9 +15,10 @@ from ansible_collections.community.dns.plugins.module_utils.provider import (
 
 
 class CustomProviderInformation(ProviderInformation):
-    def __init__(self, txt_record_handling='decoded'):
+    def __init__(self, txt_record_handling='decoded', txt_character_encoding='decimal'):
         super(CustomProviderInformation, self).__init__()
         self._txt_record_handling = txt_record_handling
+        self._txt_character_encoding = txt_character_encoding
 
     def get_supported_record_types(self):
         return ['A']
@@ -33,6 +34,9 @@ class CustomProviderInformation(ProviderInformation):
 
     def txt_record_handling(self):
         return self._txt_record_handling
+
+    def txt_character_encoding(self):
+        return self._txt_character_encoding
 
 
 class CustomProvideOptions(object):

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
@@ -681,7 +681,7 @@ class TestHetznerDNSRecordSetInfoJSON(BaseTestModule):
         assert 'deprecations' in result
         found = False
         for deprecation in result['deprecations']:
-            if deprecation['collection_name'] != 'community.dns':
+            if 'collection_name' in deprecation and deprecation['collection_name'] != 'community.dns':
                 continue
             found = True
             assert deprecation['msg'] == (

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
@@ -679,15 +679,18 @@ class TestHetznerDNSRecordSetInfoJSON(BaseTestModule):
         assert result['set']['value'] == [u'"b\\303\\244r \\"with quotes\\" (use \\\\ to escape)"']
         assert 'sets' not in result
         assert 'deprecations' in result
-        assert len(result['deprecations']) == 1
-        assert result['deprecations'][0] == {
-            'msg': (
+        found = False
+        for deprecation in result['deprecations']:
+            if deprecation['collection_name'] != 'community.dns':
+                continue
+            found = True
+            assert deprecation['msg'] == (
                 'The default of the txt_character_encoding option will change from "octal" to "decimal" in community.dns 3.0.0.'
                 ' This potentially affects you since you use txt_transformation=quoted.'
                 ' You can explicitly set txt_character_encoding to "octal" to keep the current behavior,'
                 ' or "decimal" to already now switch to the new behavior.'
                 ' We recommend switching to the new behavior, and using check/diff mode to figure out potential changes'
-            ),
-            'version': '3.0.0',
-            'collection_name': 'community.dns',
-        }
+            )
+            assert deprecation['version'] == '3.0.0'
+            assert deprecation.get('date') is None
+        assert found


### PR DESCRIPTION
##### SUMMARY
While working on #133 I noticed that DNSPython (and most of the remainder of the world) uses decimal escape sequences for quoted TXT entries, while the code in community.dns uses octal escape sequences. When talking to the API this makes no difference for the APIs currently implemented in this collection (Hosttech uses decoded strings, and Hetzner uses encoded strings, but with no encoding for Unicode characters). But when the user specifies `txt_transform=quoted` this produces different results depending on the input.

This PR adds a new option `txt_character_encoding` (current default: `octal`) that allows to select this behavior, and allows APIs that use such escape sequences to declare the encoding they use.

The defaults for this option and the API declaration will change from `octal` to `decimal` in community.dns 3.0.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various modules and plugins
