### PR TITLE
CI: ansible-core devel drops support for Python 3.5

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -108,7 +108,6 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.5
           - 3.6
           - 3.7
           - 3.8
@@ -141,6 +140,8 @@ jobs:
           # 2.15
           - ansible: stable-2.15
             python: "2.7"
+          - ansible: stable-2.15
+            python: "3.5"
           - ansible: stable-2.15
             python: "3.11"
 


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/46

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
