### PR TITLE
Disable EE with ansible-core devel for now until UBI 9 has Python 3.10 support

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -43,11 +43,11 @@ jobs:
         exclude:
           - ansible_core: ''
         include:
-          - name: ansible-core devel @ RHEL UBI 9
-            ansible_core: https://github.com/ansible/ansible/archive/devel.tar.gz
-            ansible_runner: ansible-runner
-            base_image: docker.io/redhat/ubi9:latest
-            pre_base: '"#"'
+          # - name: ansible-core devel @ RHEL UBI 9
+          #   ansible_core: https://github.com/ansible/ansible/archive/devel.tar.gz
+          #   ansible_runner: ansible-runner
+          #   base_image: docker.io/redhat/ubi9:latest
+          #   pre_base: '"#"'
           - name: ansible-core 2.15 @ Rocky Linux 9
             ansible_core: https://github.com/ansible/ansible/archive/stable-2.15.tar.gz
             ansible_runner: ansible-runner


### PR DESCRIPTION
##### SUMMARY
ansible-core devel now needs Python 3.10+, but the RHEL UBI 9 does not have Python 3.10 support yet apparently.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
EE CI
