### PR TITLE
Fix CI for ansible-base 2.10 and Ansible 2.9

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -89,6 +89,8 @@ jobs:
           # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
           pre-test-cmd: >-
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
+            ;
+            tests/unit/replace-requirements.sh requirements-${{ matrix.ansible }}.txt
 
   integration:
     # Ansible-test on various stable branches does not yet work well with cgroups v2.

--- a/tests/unit/replace-requirements.sh
+++ b/tests/unit/replace-requirements.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+DIRECTORY="$(dirname "$0")"
+
+if [ -e "${DIRECTORY}/$1" ]; then
+    cp "${DIRECTORY}/$1" "${DIRECTORY}/requirements.txt"
+fi

--- a/tests/unit/requirements-stable-2.10.txt
+++ b/tests/unit/requirements-stable-2.10.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unittest2 ; python_version < '2.7'
+importlib ; python_version < '2.7'
+
+dnspython < 2.4.0
+
+lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
+lxml ; python_version >= '2.7'

--- a/tests/unit/requirements-stable-2.9.txt
+++ b/tests/unit/requirements-stable-2.9.txt
@@ -1,0 +1,11 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unittest2 ; python_version < '2.7'
+importlib ; python_version < '2.7'
+
+dnspython < 2.4.0
+
+lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
+lxml ; python_version >= '2.7'


### PR DESCRIPTION
##### SUMMARY
dnspython 2.4 broke unit tests on Python 3.8 for ansible-base 2.10.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
