### PR TITLE
Fixed CAA example

### DIFF
--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -129,10 +129,10 @@ EXAMPLES = '''
     zone: foo.com
     record: foo.com
     type: CAA
-    ttl: 3600
+    ttl: null
     value:
-    - "128 issue letsencrypt.org"
-    - "128 iodef mailto:webmaster@foo.com"
+    - "128 issue \"letsencrypt.org\""
+    - "128 iodef \"mailto:webmaster@foo.com\""
     hetzner_token: access_token
 
 - name: Add an MX record

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -130,7 +130,7 @@ EXAMPLES = '''
     record: foo.com
     type: CAA
     value:
-    - "128 issue \"letsencrypt.org\""
+    - '128 issue "letsencrypt.org"'
     - '128 iodef "mailto:webmaster@foo.com"'
     hetzner_token: access_token
 

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -131,7 +131,7 @@ EXAMPLES = '''
     type: CAA
     value:
     - "128 issue \"letsencrypt.org\""
-    - "128 iodef \"mailto:webmaster@foo.com\""
+    - '128 iodef "mailto:webmaster@foo.com"'
     hetzner_token: access_token
 
 - name: Add an MX record

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -129,7 +129,6 @@ EXAMPLES = '''
     zone: foo.com
     record: foo.com
     type: CAA
-    ttl: null
     value:
     - "128 issue \"letsencrypt.org\""
     - "128 iodef \"mailto:webmaster@foo.com\""


### PR DESCRIPTION
##### SUMMARY

`ttl: 3600` isn't allowed by Hetzner and will result in `422 Unprocessable Entity: format: invalid CAA string;`, using `null` will use Hetzners default value, so it should always work.

Also added quotes to the values.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.dns.hetzner_dns_record_set
