### PR TITLE
Introduce server specification in nameserver_info module

### DIFF
--- a/changelogs/fragments/168-custom-dns-server.yml
+++ b/changelogs/fragments/168-custom-dns-server.yml
@@ -1,3 +1,2 @@
 minor_changes:
-  - nameserver_info and nameserver_record_info - add servers parameter to specify custom DNS servers
-  - ResolveDirectlyFromNameServers class - accepts custom server_addresses addresses.
+  - nameserver_info and nameserver_record_info - add servers parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/168)

--- a/changelogs/fragments/168-custom-dns-server.yml
+++ b/changelogs/fragments/168-custom-dns-server.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nameserver_info and nameserver_record_info - add servers parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/168)
+  - nameserver_info and nameserver_record_info - add ``servers`` parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/168).

--- a/changelogs/fragments/168-custom-dns-server.yml
+++ b/changelogs/fragments/168-custom-dns-server.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nameserver_info and nameserver_record_info - add servers parameter to specify custom DNS servers
+  - ResolveDirectlyFromNameServers class - accepts custom server_addresses addresses.

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -132,14 +132,14 @@ class SimpleResolver(_Resolve):
 
 
 class ResolveDirectlyFromNameServers(_Resolve):
-    def __init__(self, timeout=10, timeout_retries=3, servfail_retries=0, always_ask_default_resolver=True):
+    def __init__(self, timeout=10, timeout_retries=3, servfail_retries=0, always_ask_default_resolver=True, server_addresses=None):
         super(ResolveDirectlyFromNameServers, self).__init__(
             timeout=timeout,
             timeout_retries=timeout_retries,
             servfail_retries=servfail_retries,
         )
         self.cache = {}
-        self.default_nameservers = self.default_resolver.nameservers
+        self.default_nameservers = self.default_resolver.nameservers if server_addresses is None else server_addresses
         self.always_ask_default_resolver = always_ask_default_resolver
 
     def _lookup_ns_names(self, target, nameservers=None, nameserver_ips=None):
@@ -221,6 +221,8 @@ class ResolveDirectlyFromNameServers(_Resolve):
         return result
 
     def _get_resolver(self, dnsname, nameservers):
+        if self.default_nameservers != self.default_resolver.nameservers:
+            nameservers = self.default_nameservers
         cache_index = ('|'.join([str(dnsname)] + sorted(nameservers)), 'resolver')
         resolver = self.cache.get(cache_index)
         if resolver is None:

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -221,8 +221,6 @@ class ResolveDirectlyFromNameServers(_Resolve):
         return result
 
     def _get_resolver(self, dnsname, nameservers):
-        if self.default_nameservers != self.default_resolver.nameservers:
-            nameservers = self.default_nameservers
         cache_index = ('|'.join([str(dnsname)] + sorted(nameservers)), 'resolver')
         resolver = self.cache.get(cache_index)
         if resolver is None:

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -61,6 +61,7 @@ options:
         description:
             - A list of DNS server IP addresses to use for resolving nameserver information.
             - When specified, these servers are used instead of the system's default DNS settings.
+            - This must be a list of IP addresses.
         type: list
         elements: str
         version_added: 2.7.0

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -143,9 +143,8 @@ def main():
 
     names = module.params['name']
     resolve_addresses = module.params['resolve_addresses']
-
     servers = module.params['servers']
-    
+
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
         timeout_retries=module.params['query_retry'],

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -143,14 +143,13 @@ def main():
 
     names = module.params['name']
     resolve_addresses = module.params['resolve_addresses']
-    servers = module.params['servers']
 
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
-        server_addresses=servers,
+        server_addresses=module.params['servers'],
     )
     results = [None] * len(names)
     for index, name in enumerate(names):

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -64,6 +64,7 @@ options:
         type: list
         elements: str
         required: false
+        default: null
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 '''

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -127,6 +127,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
+            servers=dict(required=False, type='list', elements='str'),
         ),
         supports_check_mode=True,
     )
@@ -135,11 +136,14 @@ def main():
     names = module.params['name']
     resolve_addresses = module.params['resolve_addresses']
 
+    servers = module.params['servers']
+    
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
+        server_addresses=servers,
     )
     results = [None] * len(names)
     for index, name in enumerate(names):

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -134,7 +134,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
-            servers=dict(required=False, type='list', elements='str'),
+            servers=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
     )

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -57,6 +57,13 @@ options:
             - How often to retry on SERVFAIL errors.
         type: int
         default: 0
+    servers:
+        description:
+            - A list of DNS server IP addresses to use for resolving nameserver information.
+            - When specified, these servers are used instead of the system's default DNS settings.
+        type: list
+        elements: str
+        required: false
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 '''

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -63,8 +63,7 @@ options:
             - When specified, these servers are used instead of the system's default DNS settings.
         type: list
         elements: str
-        required: false
-        default: null
+        version_added: 2.7.0
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 '''

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -84,6 +84,14 @@ options:
             - How often to retry on SERVFAIL errors.
         type: int
         default: 0
+    servers:
+        description:
+            - A list of DNS server IP addresses to use for resolving nameserver information.
+            - When specified, these servers are used instead of the system's default DNS settings.
+            - This must be a list of IP addresses.
+        type: list
+        elements: str
+        version_added: 2.7.0
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 notes:
@@ -512,6 +520,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
+            servers=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
     )
@@ -525,6 +534,7 @@ def main():
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
+        server_addresses=module.params['servers'],
     )
     results = [None] * len(names)
     for index, name in enumerate(names):

--- a/tests/integration/targets/nameserver_info/tasks/main.yml
+++ b/tests/integration/targets/nameserver_info/tasks/main.yml
@@ -28,3 +28,32 @@
       - result.results[0].nameservers[0] == 'a.iana-servers.net.'
       - result.results[0].nameservers[1] == 'b.iana-servers.net.'
       - result.results[0].nameservers[0] != 'b.iana-servers.net.'
+
+- name: Retrieve name servers of two DNS names using custom DNS servers
+  community.dns.nameserver_info:
+    name:
+      - www.example.com
+      - example.org
+    servers:
+      - 208.67.222.222
+      - 208.67.220.220
+  register: result
+
+- name: Show TXT values for www.example.com for all nameservers
+  ansible.builtin.debug:
+    msg: '{{ result }}'
+
+- name: Show nameservers for www.example.com
+  ansible.builtin.debug:
+    msg: '{{ result.results[0].nameservers }}'
+
+- name: Show TXT values for www.example.com for first nameserver
+  ansible.builtin.debug:
+    msg: '{{ result.results[0].nameservers[0] }}'
+
+- name: Validate results
+  assert:
+    that:
+      - result.results[0].nameservers[0] == 'a.iana-servers.net.'
+      - result.results[0].nameservers[1] == 'b.iana-servers.net.'
+      - result.results[0].nameservers[0] != 'b.iana-servers.net.'

--- a/tests/integration/targets/nameserver_record_info/tasks/main.yml
+++ b/tests/integration/targets/nameserver_record_info/tasks/main.yml
@@ -13,6 +13,32 @@
 
 - name: Show TXT values for www.example.com for all nameservers
   ansible.builtin.debug:
+    msg: '{{ result }}'
+
+- name: Show TXT values for www.example.com for first nameserver
+  ansible.builtin.debug:
+    msg: '{{ result.results[0].result[0].nameserver  }}'
+
+- name: Validate results
+  assert:
+    that:
+      - result.results[0].result[0].nameserver == 'a.iana-servers.net.'
+      - result.results[0].result[1].nameserver == 'b.iana-servers.net.'
+      - result.results[0].result[0].nameserver != 'b.iana-servers.net.'
+
+- name: Retrieve TXT values from all nameservers for two DNS names using custom DNS servers
+  community.dns.nameserver_record_info:
+    name:
+      - www.example.com
+      - example.org
+    type: TXT
+    servers:
+      - 208.67.222.222
+      - 208.67.220.220
+  register: result
+
+- name: Show TXT values for www.example.com for all nameservers
+  ansible.builtin.debug:
     msg: '{{ result  }}'
 
 - name: Show TXT values for www.example.com for all nameservers


### PR DESCRIPTION
##### SUMMARY
This merge request introduces the ability to specify custom DNS servers for resolving nameserver information in the nameserver_info module. It includes enhancements to the ResolveDirectlyFromNameServers class to handle custom server addresses and updates the nameserver_info module to accept a new 'servers' parameter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
community.dns.nameserver_info

##### ADDITIONAL INFORMATION
