### PR TITLE
nameserver_record_info: fix crash when more than one record is retrieved

### DIFF
--- a/changelogs/fragments/172-nameserver_record_info.yml
+++ b/changelogs/fragments/172-nameserver_record_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "nameserver_record_info - fix crash when more than one record is retrieved (https://github.com/ansible-collections/community.dns/pull/172)."

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -548,7 +548,7 @@ def main():
                 if records is not None:
                     for data in records:
                         values.append(convert_rdata_to_dict(data))
-                ns_result['values'] = sorted(values)
+                ns_result['values'] = values
             result.sort(key=lambda v: v['nameserver'])
 
     guarded_run(f, module, generate_additional_results=lambda: dict(results=results))

--- a/tests/unit/plugins/modules/test_nameserver_record_info.py
+++ b/tests/unit/plugins/modules/test_nameserver_record_info.py
@@ -97,6 +97,7 @@ class TestNameserverRecordInfo(ModuleTestCase):
                         'example.org',
                         300,
                         dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, 'asdf'),
+                        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.TXT, 'fdsa'),
                     )),
                 },
             ],
@@ -200,7 +201,11 @@ class TestNameserverRecordInfo(ModuleTestCase):
             {
                 'strings': ['asdf'],
                 'value': 'asdf',
-            }
+            },
+            {
+                'strings': ['fdsa'],
+                'value': 'fdsa',
+            },
         ]
 
     def test_timeout(self):


### PR DESCRIPTION
##### SUMMARY
Ref: #171

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nameserver_record_info
