### PR TITLE
Rename 'servers' to 'server' for nameserver_*info; add 'server' parameter to wait_for_txt

### DIFF
--- a/changelogs/fragments/168-custom-dns-server.yml
+++ b/changelogs/fragments/168-custom-dns-server.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nameserver_info and nameserver_record_info - add ``servers`` parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/168).
+  - nameserver_info and nameserver_record_info - add ``server`` parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/168, https://github.com/ansible-collections/community.dns/pull/178).

--- a/changelogs/fragments/178-wait_for_txt-server.yml
+++ b/changelogs/fragments/178-wait_for_txt-server.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - wait_for_txt - add ``server`` parameter to specify custom DNS servers (https://github.com/ansible-collections/community.dns/pull/178).

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -67,7 +67,7 @@ options:
         default: 10
     server:
         description:
-            - The DNS server(s) to use to look up the result.
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
             - By default, the system's standard resolver is used.
         type: list
         elements: str

--- a/plugins/lookup/lookup_as_dict.py
+++ b/plugins/lookup/lookup_as_dict.py
@@ -67,7 +67,7 @@ options:
         default: 10
     server:
         description:
-            - The DNS server(s) to use to look up the result.
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
             - By default, the system's standard resolver is used.
         type: list
         elements: str

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -46,7 +46,7 @@ options:
     always_ask_default_resolver:
         description:
             - When set to V(true) (default), will use the default resolver to find the authoritative nameservers
-              of a subzone.
+              of a subzone. See O(server) for how to configure the default resolver.
             - When set to V(false), will use the authoritative nameservers of the parent zone to find the
               authoritative nameservers of a subzone. This only makes sense when the nameservers were recently
               changed and have not yet propagated.
@@ -57,11 +57,10 @@ options:
             - How often to retry on SERVFAIL errors.
         type: int
         default: 0
-    servers:
+    server:
         description:
-            - A list of DNS server IP addresses to use for resolving nameserver information.
-            - When specified, these servers are used instead of the system's default DNS settings.
-            - This must be a list of IP addresses.
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
+            - By default, the system's standard resolver is used.
         type: list
         elements: str
         version_added: 2.7.0
@@ -135,7 +134,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
-            servers=dict(type='list', elements='str'),
+            server=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
     )
@@ -149,7 +148,7 @@ def main():
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
-        server_addresses=module.params['servers'],
+        server_addresses=module.params['server'],
     )
     results = [None] * len(names)
     for index, name in enumerate(names):

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -73,7 +73,7 @@ options:
     always_ask_default_resolver:
         description:
             - When set to V(true) (default), will use the default resolver to find the authoritative nameservers
-              of a subzone.
+              of a subzone. See O(server) for how to configure the default resolver.
             - When set to V(false), will use the authoritative nameservers of the parent zone to find the
               authoritative nameservers of a subzone. This only makes sense when the nameservers were recently
               changed and have not yet propagated.
@@ -84,11 +84,10 @@ options:
             - How often to retry on SERVFAIL errors.
         type: int
         default: 0
-    servers:
+    server:
         description:
-            - A list of DNS server IP addresses to use for resolving nameserver information.
-            - When specified, these servers are used instead of the system's default DNS settings.
-            - This must be a list of IP addresses.
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
+            - By default, the system's standard resolver is used.
         type: list
         elements: str
         version_added: 2.7.0
@@ -520,7 +519,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
-            servers=dict(type='list', elements='str'),
+            server=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
     )
@@ -534,7 +533,7 @@ def main():
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
-        server_addresses=module.params['servers'],
+        server_addresses=module.params['server'],
     )
     results = [None] * len(names)
     for index, name in enumerate(names):

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -94,7 +94,7 @@ options:
     always_ask_default_resolver:
         description:
             - When set to V(true) (default), will use the default resolver to find the authoritative nameservers
-              of a subzone.
+              of a subzone. See O(server) for how to configure the default resolver.
             - When set to V(false), will use the authoritative nameservers of the parent zone to find the
               authoritative nameservers of a subzone. This only makes sense when the nameservers were recently
               changed and have not yet propagated.
@@ -106,6 +106,13 @@ options:
         type: int
         default: 0
         version_added: 2.6.0
+    server:
+        description:
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
+            - By default, the system's standard resolver is used.
+        type: list
+        elements: str
+        version_added: 2.7.0
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 '''
@@ -251,6 +258,7 @@ class Waiter(object):
             timeout_retries=self.module.params['query_retry'],
             servfail_retries=self.module.params['servfail_retries'],
             always_ask_default_resolver=self.module.params['always_ask_default_resolver'],
+            server_addresses=self.module.params['server'],
         )
         self.records = self.module.params['records']
         self.timeout = self.module.params['timeout']
@@ -334,6 +342,7 @@ def main():
             max_sleep=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
+            server=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
     )

--- a/tests/integration/targets/nameserver_info/tasks/main.yml
+++ b/tests/integration/targets/nameserver_info/tasks/main.yml
@@ -34,7 +34,7 @@
     name:
       - www.example.com
       - example.org
-    servers:
+    server:
       # Quad9 servers (https://en.wikipedia.org/wiki/Quad9#Service)
       - 9.9.9.9
       - 149.112.112.112

--- a/tests/integration/targets/nameserver_record_info/tasks/main.yml
+++ b/tests/integration/targets/nameserver_record_info/tasks/main.yml
@@ -32,7 +32,7 @@
       - www.example.com
       - example.org
     type: TXT
-    servers:
+    server:
       # Quad9 servers (https://en.wikipedia.org/wiki/Quad9#Service)
       - 9.9.9.9
       - 149.112.112.112


### PR DESCRIPTION
##### SUMMARY
Update #168 to use the same parameter names as for the lookup plugins. Also add the new `server` parameter to wait_for_txt.

CC @hakong

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
nameserver_info
nameserver_record_info
wait_for_txt
