### PR TITLE
Inventory plugins: rename filters to simple_filters

### DIFF
--- a/changelogs/fragments/181-inventory-filters.yml
+++ b/changelogs/fragments/181-inventory-filters.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - hetzner_dns_records and hosttech_dns_records inventory plugins - the ``filters`` option has been renamed to ``simple_filters``.
+    The old name still works until community.hrobot 2.0.0.
+    Then it will change to allow more complex filtering with the ``community.library_inventory_filtering_v1`` collection's functionality
+    (https://github.com/ansible-collections/community.dns/pull/181).

--- a/changelogs/fragments/181-inventory-filters.yml
+++ b/changelogs/fragments/181-inventory-filters.yml
@@ -3,3 +3,6 @@ minor_changes:
     The old name still works until community.hrobot 2.0.0.
     Then it will change to allow more complex filtering with the ``community.library_inventory_filtering_v1`` collection's functionality
     (https://github.com/ansible-collections/community.dns/pull/181).
+deprecated_features:
+  - hetzner_dns_records and hosttech_dns_records inventory plugins - the ``filters`` option has been renamed to ``simple_filters``.
+    The old name will stop working in community.hrobot 2.0.0 (https://github.com/ansible-collections/community.dns/pull/181).

--- a/plugins/doc_fragments/hetzner.py
+++ b/plugins/doc_fragments/hetzner.py
@@ -147,7 +147,7 @@ options:
     #          DO NOT EDIT MANUALLY!
     RECORD_TYPE_CHOICES_RECORDS_INVENTORY = r'''
 options:
-    filters:
+    simple_filters:
         suboptions:
             type:
                 description:

--- a/plugins/doc_fragments/hosttech.py
+++ b/plugins/doc_fragments/hosttech.py
@@ -160,7 +160,7 @@ options:
     #          DO NOT EDIT MANUALLY!
     RECORD_TYPE_CHOICES_RECORDS_INVENTORY = r'''
 options:
-    filters:
+    simple_filters:
         suboptions:
             type:
                 description:

--- a/plugins/doc_fragments/inventory_records.py
+++ b/plugins/doc_fragments/inventory_records.py
@@ -31,10 +31,14 @@ options:
         description:
           - The ID of the DNS zone to modify.
           - Exactly one of O(zone_name) and O(zone_id) must be specified.
-    filters:
+    simple_filters:
         description:
           - A dictionary of filter value pairs.
+          - This option has been renamed from O(filters) to O(simple_filters) in community.dns 2.8.0.
+            The old name can still be used until community.dns 3.0.0.
         type: dict
+        aliases:
+          - filters
         default: {}
         suboptions:
             # (The following must be kept in sync with the equivalent lines in <provider_name>.py!)

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -55,7 +55,7 @@ EXAMPLES = '''
 
 plugin: community.dns.hetzner_dns_records
 zone_name: domain.de
-filters:
+simple_filters:
   type:
     - TXT
 txt_transformation: unquoted

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -63,7 +63,7 @@ EXAMPLES = '''
 
 plugin: community.dns.hosttech_dns_records
 zone_name: domain.ch
-filters:
+simple_filters:
   type:
     - AAAA
 

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -65,7 +65,15 @@ class RecordsInventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=False):
         super(RecordsInventoryModule, self).parse(inventory, loader, path, cache)
 
-        self._read_config_data(path)
+        orig_config = self._read_config_data(path)
+
+        if 'filters' in orig_config:
+            display.deprecated(
+                'The `filters` option of the %s inventory plugin has been renamed to `simple_filters`. '
+                'The old name will stop working in community.dns 3.0.0.' % self.NAME,
+                collection_name='community.dns',
+                version='3.0.0',
+            )
 
         self.templar = Templar(loader=loader)
 

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -109,7 +109,7 @@ class RecordsInventoryModule(BaseInventoryPlugin):
         except DNSAPIError as e:
             raise AnsibleError('Error: %s' % e)
 
-        filters = self.get_option('filters')
+        filters = self.get_option('simple_filters')
 
         filter_types = filters.get('type') or ['A', 'AAAA', 'CNAME']
         if not isinstance(filter_types, Sequence) or isinstance(filter_types, six.string_types):

--- a/update-docs-fragments.py
+++ b/update-docs-fragments.py
@@ -42,7 +42,7 @@ DEPENDENT_FRAGMENTS = [
         ]),
     ]),
     ('RECORD_TYPE_CHOICES_RECORDS_INVENTORY', [
-        ('record_type', 'options.filters.suboptions.type', [
+        ('record_type', 'options.simple_filters.suboptions.type', [
             'inventory_records',
         ]),
     ]),


### PR DESCRIPTION
##### SUMMARY
This allows to re-use `filters` for the functionality provided by [community.library_inventory_filtering_v1](https://github.com/ansible-collections/community.library_inventory_filtering/) in the next major release.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventory plugins
