### PR TITLE
TXT encoding: avoid breaking up quoting of double quotes and backslashes

### DIFF
--- a/changelogs/fragments/191-txt-quoting.yml
+++ b/changelogs/fragments/191-txt-quoting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "DNS record modules, inventory plugins - fix the TXT entry encoder to avoid splitting up escape sequences for quotes and backslashes over multiple TXT strings (https://github.com/ansible-collections/community.dns/issues/190, https://github.com/ansible-collections/community.dns/pull/191)."

--- a/plugins/module_utils/conversion/txt.py
+++ b/plugins/module_utils/conversion/txt.py
@@ -183,6 +183,10 @@ def encode_txt_value(value, always_quote=False, use_character_encoding=_SENTINEL
 
         # Add letter
         if letter in (b'"', b'\\'):
+            # Make sure that we don't split up an escape sequence over multiple TXT strings
+            if len(buffer) + 2 > 255:
+                append(buffer[:255])
+                buffer = buffer[255:]
             buffer.append(b'\\')
             buffer.append(letter)
         elif use_character_encoding and not (0x20 <= ord(letter) < 0x7F):

--- a/tests/unit/plugins/module_utils/conversion/test_txt.py
+++ b/tests/unit/plugins/module_utils/conversion/test_txt.py
@@ -138,6 +138,16 @@ TEST_ENCODE_DECODE = [
         True, True, 'decimal'
     ),
     (
+        # Avoid splitting up an escape into multiple TXT strings
+        u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
+        u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef"\\',
+        u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
+        u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'
+        u'456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdef \\"\\\\',
+        False, True, 'decimal'
+    ),
+    (
         # Avoid splitting up an decimal sequence into multiple TXT strings
         u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB'
         u'CDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123'


### PR DESCRIPTION
##### SUMMARY
Fixes #190.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
TXT encoding
