### PR TITLE
Add changelog to docsite

### DIFF
--- a/docs/docsite/config.yml
+++ b/docs/docsite/config.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+changelog:
+  write_changelog: true


### PR DESCRIPTION
##### SUMMARY
Uses https://github.com/ansible-community/antsibull-docs/pull/267 to render changelog.

I had to add e4cd0ec9c47362c26deac2df99aa5973b7d41bac to `main` first so that my branch is used.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite
