### PR TITLE
CI: restrict lxml to < 5.2.0 for ansible-base 2.10 unit tests

### DIFF
--- a/tests/unit/requirements-stable-2.10.txt
+++ b/tests/unit/requirements-stable-2.10.txt
@@ -10,4 +10,4 @@ ipaddress ; python_version < '3.3'
 dnspython < 2.4.0
 
 lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
-lxml ; python_version >= '2.7'
+lxml < 5.2.0 ; python_version >= '2.7'  # lxml 5.2.0 does fail with Python 3.6 due to TOML loading failure


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/community.dns/actions/runs/8503870587/job/23292353671

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit test requirements
