### PR TITLE
[3.0.0] Prepare new major release: remove deprecations, add community.library_inventory_filtering_v1 dependency, add new filter option

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
+          pre-test-cmd: >-
+            git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
 
   units:
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
@@ -92,6 +94,8 @@ jobs:
           testing-type: units
           # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
           pre-test-cmd: >-
+            git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
+            ;
             git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
             ;
             tests/unit/replace-requirements.sh requirements-${{ matrix.ansible }}.txt
@@ -170,6 +174,8 @@ jobs:
           integration-retry-on-error: 'true'
           # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
           pre-test-cmd: >-
+            git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
+            ;
             tests/integration/replace-requirements.sh requirements-${{ matrix.ansible }}.txt
           target-python-version: ${{ matrix.python }}
           testing-type: integration

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -29,25 +29,12 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
           - stable-2.17
           - devel
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
@@ -58,26 +45,13 @@ jobs:
             git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ../../community/library_inventory_filtering_v1
 
   units:
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["stable-2.9", "stable-2.10", "stable-2.11"]'
-      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       # As soon as the first unit test fails, cancel the others to free up the CI queue
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.9
-          - stable-2.10
-          - stable-2.11
-          - stable-2.12
-          - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16
@@ -123,26 +97,11 @@ jobs:
           - "3.11"
           - "3.12"
         include:
-          # 2.9
-          - ansible: stable-2.9
-            python: "2.7"
-          - ansible: stable-2.9
-            python: "3.6"
-          # 2.10
-          - ansible: stable-2.10
-            python: "3.5"
-          # 2.11
-          - ansible: stable-2.11
-            python: "2.7"
-          # 2.12
-          - ansible: stable-2.12
-            python: "2.6"
-          - ansible: stable-2.12
-            python: "3.5"
-          # 2.13
-          - ansible: stable-2.13
-            python: "3.6"
           # 2.14
+          - ansible: stable-2.14
+            python: "2.7"
+          - ansible: stable-2.14
+            python: "3.5"
           - ansible: stable-2.14
             python: "3.9"
           # 2.15

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -62,22 +62,6 @@ jobs:
             ansible_runner: ansible-runner
             base_image: quay.io/centos/centos:stream9
             pre_base: '"#"'
-          - name: ansible-core 2.13 @ RHEL UBI 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.13.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: docker.io/redhat/ubi8:latest
-            pre_base: '"#"'
-          - name: ansible-core 2.12 @ CentOS Stream 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.12.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: quay.io/centos/centos:stream8
-            pre_base: '"#"'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/extra-tests.yml
+++ b/.github/workflows/extra-tests.yml
@@ -39,9 +39,11 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
       - name: Install collection dependencies
-        run: git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ./ansible_collections/community/internal_test_tools
+        run: |
+          git clone --depth=1 --single-branch --branch stable-1 https://github.com/ansible-collections/community.library_inventory_filtering.git ./ansible_collections/community/library_inventory_filtering_v1
+          git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ./ansible_collections/community/internal_test_tools
         # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
-        # run: ansible-galaxy collection install community.internal_test_tools -p .
+        # run: ansible-galaxy collection install community.internal_test_tools community.library_inventory_filtering_v1 -p .
 
       - name: Run sanity tests
         run: ../../community/internal_test_tools/tools/run.py --color

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note that this collection does **not** support Windows targets.
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -14,3 +14,6 @@ major_changes:
 breaking_changes:
   - "The default for the ``txt_character_encoding`` options in various modules and plugins changed from ``octal`` to ``decimal``
      (https://github.com/ansible-collections/community.dns/pull/196)."
+removed_features:
+  - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
+     (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -22,6 +22,13 @@ removed_features:
      (https://github.com/ansible-collections/community.dns/pull/196)."
   - "hosttech_dns_records - the redirect to the ``hosttech_dns_record_sets`` module has been removed
      (https://github.com/ansible-collections/community.dns/pull/196)."
+  - "The collection no longer supports Ansible, ansible-base, and ansible-core releases
+     that are currently End of Life at the time of the 3.0.0 release. This means that
+     Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13,
+     and ansible-core 2.14 are no longer supported. The collection might still work with these
+     versions, but it can stop working at any moment without advance notice, and this will not
+     be considered a bug
+     (https://github.com/ansible-collections/community.dns/pull/196)."
 minor_changes:
   - "inventory plugins - add ``filter`` option which allows to include and exclude
      hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -14,6 +14,7 @@ major_changes:
 breaking_changes:
   - "The default for the ``txt_character_encoding`` options in various modules and plugins changed from ``octal`` to ``decimal``
      (https://github.com/ansible-collections/community.dns/pull/196)."
+  - "inventory plugins - the ``plugin`` option is now required (https://github.com/ansible-collections/community.dns/pull/196).
 removed_features:
   - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
      (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -20,3 +20,6 @@ breaking_changes:
 removed_features:
   - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
      (https://github.com/ansible-collections/community.dns/pull/196)."
+minor_changes:
+  - "inventory plugins - add ``filter`` option which allows to include and exclude
+     hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -1,0 +1,13 @@
+release_summary: |
+  ...
+major_changes:
+  - The ``community.dns`` collection now depends on the ``community.library_inventory_filtering_v1``
+    collection. This utility collection provides host filtering functionality
+    for inventory plugins. If you use the Ansible community package, both collections
+    are included and you do not have to do anything special. If you install the
+    collection with ``ansible-galaxy collection install``, it will be installed
+    automatically. If you install the collection by copying the files of the collection
+    to a place where ansible-core can find it, for example by cloning the git
+    repository, you need to make sure that you also have to install the dependency
+    if you are using the inventory plugins
+    (https://github.com/ansible-collections/community.dns/pull/196).

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -11,3 +11,6 @@ major_changes:
     repository, you need to make sure that you also have to install the dependency
     if you are using the inventory plugins
     (https://github.com/ansible-collections/community.dns/pull/196).
+breaking_changes:
+  - "The default for the ``txt_character_encoding`` options in various modules and plugins changed from ``octal`` to ``decimal``
+     (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -14,9 +14,9 @@ major_changes:
 breaking_changes:
   - "The default for the ``txt_character_encoding`` options in various modules and plugins changed from ``octal`` to ``decimal``
      (https://github.com/ansible-collections/community.dns/pull/196)."
-  - "inventory plugins - the ``plugin`` option is now required (https://github.com/ansible-collections/community.dns/pull/196).
+  - "inventory plugins - the ``plugin`` option is now required (https://github.com/ansible-collections/community.dns/pull/196)."
   - "inventory plugins - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
-     (https://github.com/ansible-collections/community.dns/pull/196).
+     (https://github.com/ansible-collections/community.dns/pull/196)."
 removed_features:
   - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
      (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -20,6 +20,8 @@ breaking_changes:
 removed_features:
   - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
      (https://github.com/ansible-collections/community.dns/pull/196)."
+  - "hosttech_dns_records - the redirect to the ``hosttech_dns_record_sets`` module has been removed
+     (https://github.com/ansible-collections/community.dns/pull/196)."
 minor_changes:
   - "inventory plugins - add ``filter`` option which allows to include and exclude
      hosts based on Jinja2 conditions (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/changelogs/fragments/3.0.0.yml
+++ b/changelogs/fragments/3.0.0.yml
@@ -15,6 +15,8 @@ breaking_changes:
   - "The default for the ``txt_character_encoding`` options in various modules and plugins changed from ``octal`` to ``decimal``
      (https://github.com/ansible-collections/community.dns/pull/196)."
   - "inventory plugins - the ``plugin`` option is now required (https://github.com/ansible-collections/community.dns/pull/196).
+  - "inventory plugins - ``filters`` is now no longer an alias of ``simple_filters``, but a new, different option
+     (https://github.com/ansible-collections/community.dns/pull/196).
 removed_features:
   - "hetzner_dns_record_set, hetzner_dns_record - the deprecated alias ``name`` of the prefix option was removed
      (https://github.com/ansible-collections/community.dns/pull/196)."

--- a/docs/docsite/rst/hetzner_guide.rst
+++ b/docs/docsite/rst/hetzner_guide.rst
@@ -463,7 +463,7 @@ When :ansopt:`value` is not specified, the ``markuman.hetzner_dns.record`` modul
         # 'type' does not change:
         type: A
 
-A last step is replacing the deprecated alias :ansopt:`community.dns.hetzner_dns_record_set#module:name` of :ansopt:`community.dns.hetzner_dns_record_set#module:prefix` by :ansopt:`community.dns.hetzner_dns_record_set#module:prefix`. This can be done later though, if you do not mind the deprecation warnings.
+A last step is replacing the removed alias ``name`` of :ansopt:`community.dns.hetzner_dns_record_set#module:prefix` by :ansopt:`community.dns.hetzner_dns_record_set#module:prefix`.
 
 The markuman.hetzner_dns.record_info module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -31,3 +31,5 @@ build_ignore:
   - .gitignore
   - changelogs/.plugin-cache.yaml
   - tests/integration/integration_config.yml
+dependencies:
+  community.library_inventory_filtering_v1: '>=1.0.0'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: dns
-version: 2.9.0
+version: 3.0.0
 readme: README.md
 authors:
   - Felix Fontein (github.com/felixfontein)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -18,12 +18,10 @@ action_groups:
     - hosttech_dns_record_set_info
     - hosttech_dns_record_set
     - hosttech_dns_record_sets
-    - hosttech_dns_records   # deprecated redirect
     - hosttech_dns_zone_info
 plugin_routing:
   modules:
     hosttech_dns_records:
-      redirect: community.dns.hosttech_dns_record_sets
-      deprecation:
+      tombstone:
         removal_version: 3.0.0
         warning_text: The hosttech_dns_records module has been renamed to hosttech_dns_record_sets.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.14.0'
 action_groups:
   hetzner:
     - hetzner_dns_record_info

--- a/plugins/doc_fragments/inventory_records.py
+++ b/plugins/doc_fragments/inventory_records.py
@@ -34,11 +34,10 @@ options:
     simple_filters:
         description:
           - A dictionary of filter value pairs.
-          - This option has been renamed from O(filters) to O(simple_filters) in community.dns 2.8.0.
-            The old name can still be used until community.dns 3.0.0.
+          - This option used to be called O(filters) before community.dns 3.0.0. It has been renamed from
+            O(filters) to O(simple_filters) in community.dns 2.8.0, and the old name was still available
+            as an alias until community.dns 3.0.0. O(filters) is now used for something else.
         type: dict
-        aliases:
-          - filters
         default: {}
         suboptions:
             # (The following must be kept in sync with the equivalent lines in <provider_name>.py!)

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -55,11 +55,12 @@ options:
         description:
             - Whether to treat numeric escape sequences (V(\\xyz)) as octal or decimal numbers.
               This is only used when O(txt_transformation=quoted).
-            - The current default is V(octal) which is deprecated. It will change to V(decimal) in
-              community.dns 3.0.0. The value V(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
+            - The default changed to V(decimal) in community.dns 3.0.0. Before, the default used to be V(octal).
+              The value V(decimal) is compatible to L(RFC 1035, https://www.ietf.org/rfc/rfc1035.txt).
         type: str
         choices:
             - decimal
             - octal
+        default: decimal
         version_added: 2.5.0
 '''

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -29,6 +29,9 @@ options:
             - community.dns.hetzner_dns_records
         type: str
 
+    filters:
+        version_added: 3.0.0
+
 extends_documentation_fragment:
     - community.dns.hetzner
     - community.dns.hetzner.plugin
@@ -36,6 +39,7 @@ extends_documentation_fragment:
     - community.dns.hetzner.zone_id_type
     - community.dns.inventory_records
     - community.dns.options.record_transformation
+    - community.library_inventory_filtering_v1.inventory_filter
 
 notes:
     - The provider-specific O(hetzner_token) option can be templated.
@@ -57,6 +61,10 @@ zone_name: domain.de
 simple_filters:
   type:
     - TXT
+filters:
+  - include: >-
+      not ansible_host.startswith('v=')
+  - exclude: true
 txt_transformation: unquoted
 
 # You can also configure the token by putting secret value into this file,
@@ -65,6 +73,7 @@ txt_transformation: unquoted
 hetzner_token: >-
     {{ (lookup('community.sops.sops', 'keys/hetzner.sops.yml') | from_yaml).hetzner_dns_token }}
 '''
+
 
 from ansible_collections.community.dns.plugins.module_utils.http import (
     OpenURLHelper,

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -24,8 +24,7 @@ description:
 options:
     plugin:
         description: The name of this plugin. Should always be set to V(community.dns.hetzner_dns_records) for this plugin to recognize it as its own.
-        # TODO: add `required: true` in 3.0.0
-        # required: true
+        required: true
         choices:
             - community.dns.hetzner_dns_records
         type: str

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -24,8 +24,7 @@ description:
 options:
     plugin:
         description: The name of this plugin. Should always be set to V(community.dns.hosttech_dns_records) for this plugin to recognize it as its own.
-        # TODO: add `required: true` in 3.0.0
-        # required: true
+        required: true
         choices:
             - community.dns.hosttech_dns_records
         type: str

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -37,6 +37,9 @@ options:
         # compatibility with previous type=int...
         #   type: string
 
+    filters:
+        version_added: 3.0.0
+
 extends_documentation_fragment:
     - community.dns.hosttech
     - community.dns.hosttech.plugin
@@ -44,6 +47,7 @@ extends_documentation_fragment:
     - community.dns.hosttech.zone_id_type
     - community.dns.inventory_records
     - community.dns.options.record_transformation
+    - community.library_inventory_filtering_v1.inventory_filter
 
 notes:
     - The provider-specific O(hosttech_username), O(hosttech_password), and O(hosttech_token) options can be templated.
@@ -65,6 +69,10 @@ zone_name: domain.ch
 simple_filters:
   type:
     - AAAA
+filters:
+  - include: >-
+      '*.' not in inventory_hostname
+  - exclude: true
 
 # You can also configure the token by putting secret value into this file,
 # but this is discouraged. Use a lookup like below, or leave it away and

--- a/plugins/module_utils/conversion/converter.py
+++ b/plugins/module_utils/conversion/converter.py
@@ -44,23 +44,9 @@ class RecordConverter(object):
         self._txt_transformation = self._option_provider.get_option('txt_transformation')
         # Valid values: 'decimal', 'octal'
         self._txt_character_encoding = self._option_provider.get_option('txt_character_encoding')
-        self._txt_character_encoding_deprecation = False
-        if self._txt_character_encoding is None:
-            # TODO: remove implicit default in community.dns 3.0.0
-            self._txt_character_encoding = 'octal'
-            if self._txt_transformation == 'quoted':
-                self._txt_character_encoding_deprecation = True
 
     def emit_deprecations(self, deprecator):
-        if self._txt_character_encoding_deprecation:
-            deprecator(
-                'The default of the txt_character_encoding option will change from "octal" to "decimal" in community.dns 3.0.0.'
-                ' This potentially affects you since you use txt_transformation=quoted. You can explicitly set txt_character_encoding'
-                ' to "octal" to keep the current behavior, or "decimal" to already now switch to the new behavior. We recommend'
-                ' switching to the new behavior, and using check/diff mode to figure out potential changes',
-                version='3.0.0',
-                collection_name='community.dns',
-            )
+        pass
 
     def _handle_txt_api(self, to_api, record):
         """

--- a/plugins/module_utils/options.py
+++ b/plugins/module_utils/options.py
@@ -32,6 +32,6 @@ def create_record_transformation_argspec():
     return ArgumentSpec(
         argument_spec=dict(
             txt_transformation=dict(type='str', default='unquoted', choices=['api', 'quoted', 'unquoted']),
-            txt_character_encoding=dict(type='str', choices=['decimal', 'octal']),
+            txt_character_encoding=dict(type='str', default='decimal', choices=['decimal', 'octal']),
         ),
     )

--- a/plugins/module_utils/provider.py
+++ b/plugins/module_utils/provider.py
@@ -104,6 +104,6 @@ class ProviderInformation(object):
 
         This return value is only used if txt_record_handling returns 'encoded'.
 
-        WARNING: the default return value will change to 'decimal' for community.dns 3.0.0!
+        Note: the default return value changed from 'octal' to 'decimal' in community.dns 3.0.0.
         """
-        return 'octal'
+        return 'decimal'

--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -43,11 +43,6 @@ attributes:
     diff_mode:
         support: full
 
-options:
-    prefix:
-        aliases:
-          - name
-
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>
     - Felix Fontein (@felixfontein)
@@ -109,8 +104,6 @@ def main():
     provider_information = create_hetzner_provider_information()
     argument_spec = create_hetzner_argument_spec()
     argument_spec.merge(create_module_argument_spec(provider_information=provider_information))
-    argument_spec.argument_spec['prefix']['aliases'] = ['name']
-    argument_spec.argument_spec['prefix']['deprecated_aliases'] = [dict(name='name', version='3.0.0', collection_name='community.dns')]
     module = AnsibleModule(supports_check_mode=True, **argument_spec.to_kwargs())
     run_module(module, lambda: create_hetzner_api(ModuleOptionProvider(module), ModuleHTTPHelper(module)), provider_information=provider_information)
 

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -40,11 +40,6 @@ attributes:
     diff_mode:
         support: full
 
-options:
-    prefix:
-        aliases:
-          - name
-
 author:
     - Markus Bergholz (@markuman) <markuman+spambelongstogoogle@gmail.com>
     - Felix Fontein (@felixfontein)
@@ -224,8 +219,6 @@ def main():
     provider_information = create_hetzner_provider_information()
     argument_spec = create_hetzner_argument_spec()
     argument_spec.merge(create_module_argument_spec(provider_information=provider_information))
-    argument_spec.argument_spec['prefix']['aliases'] = ['name']
-    argument_spec.argument_spec['prefix']['deprecated_aliases'] = [dict(name='name', version='3.0.0', collection_name='community.dns')]
     module = AnsibleModule(supports_check_mode=True, **argument_spec.to_kwargs())
     run_module(module, lambda: create_hetzner_api(ModuleOptionProvider(module), ModuleHTTPHelper(module)), provider_information=provider_information)
 

--- a/plugins/modules/hosttech_dns_records.py
+++ b/plugins/modules/hosttech_dns_records.py
@@ -1,1 +1,0 @@
-hosttech_dns_record_sets.py

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -67,15 +67,7 @@ class RecordsInventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=False):
         super(RecordsInventoryModule, self).parse(inventory, loader, path, cache)
 
-        orig_config = self._read_config_data(path)
-
-        if 'filters' in orig_config:
-            display.deprecated(
-                'The `filters` option of the %s inventory plugin has been renamed to `simple_filters`. '
-                'The old name will stop working in community.dns 3.0.0.' % self.NAME,
-                collection_name='community.dns',
-                version='3.0.0',
-            )
+        self._read_config_data(path)
 
         self.templar = Templar(loader=loader)
 

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -17,6 +17,8 @@ from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.utils.display import Display
 from ansible.template import Templar
 
+from ansible_collections.community.library_inventory_filtering_v1.plugins.plugin_utils.inventory_filter import parse_filters, filter_host
+
 from ansible_collections.community.dns.plugins.module_utils.provider import (
     ensure_type,
 )
@@ -111,9 +113,10 @@ class RecordsInventoryModule(BaseInventoryPlugin):
         except DNSAPIError as e:
             raise AnsibleError('Error: %s' % e)
 
-        filters = self.get_option('simple_filters')
+        simple_filters = self.get_option('simple_filters')
+        filters = parse_filters(self.get_option('filters'))
 
-        filter_types = filters.get('type') or ['A', 'AAAA', 'CNAME']
+        filter_types = simple_filters.get('type') or ['A', 'AAAA', 'CNAME']
         if not isinstance(filter_types, Sequence) or isinstance(filter_types, six.string_types):
             filter_types = [filter_types]
 
@@ -122,5 +125,12 @@ class RecordsInventoryModule(BaseInventoryPlugin):
                 name = zone_with_records.zone.name
                 if record.prefix:
                     name = '%s.%s' % (record.prefix, name)
+                facts = {
+                    'ansible_host': make_unsafe(record.target),
+                }
+                if not filter_host(self, name, facts, filters):
+                    continue
+
                 self.inventory.add_host(name)
-                self.inventory.set_variable(name, 'ansible_host', make_unsafe(record.target))
+                for key, value in facts.items():
+                    self.inventory.set_variable(name, key, value)

--- a/tests/unit/plugins/inventory/test_hetzner_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hetzner_dns_records.py
@@ -236,7 +236,7 @@ def test_inventory_file_simple(mocker):
     plugin: community.dns.hetzner_dns_records
     hetzner_token: foo
     zone_name: example.com
-    filters:
+    simple_filters:
       type: A
     """)}
 
@@ -289,7 +289,7 @@ def test_inventory_file_collision(mocker):
     plugin: community.dns.hetzner_dns_records
     hetzner_token: '{{ "foo" }}'
     zone_name: '{{ "example." ~ "com" }}'
-    filters:
+    simple_filters:
       type:
         - A
         - AAAA

--- a/tests/unit/plugins/inventory/test_hosttech_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hosttech_dns_records.py
@@ -220,7 +220,7 @@ def test_inventory_file_simple(mocker):
     plugin: community.dns.hosttech_dns_records
     hosttech_token: foo
     zone_name: example.com
-    filters:
+    simple_filters:
       type: A
     """)}
 
@@ -270,7 +270,7 @@ def test_inventory_file_collision(mocker):
     plugin: community.dns.hosttech_dns_records
     hosttech_token: "{{ 'foo' }}"
     zone_name: "{{ 'example' ~ '.com' }}"
-    filters:
+    simple_filters:
       type:
         - A
         - AAAA

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
@@ -627,7 +627,7 @@ class TestHetznerDNSRecordSetInfoJSON(BaseTestModule):
         assert result['set']['value'] == [u'"b\\195\\164r \\"with quotes\\" (use \\\\ to escape)"']
         assert 'sets' not in result
 
-    def test_get_single_txt_quoted_deprecation(self, mocker):
+    def test_get_single_txt_quoted_octal(self, mocker):
         with patch('time.sleep', mock_sleep):
             result = self.run_module_success(mocker, hetzner_dns_record_set_info, {
                 'hetzner_token': 'foo',
@@ -635,6 +635,7 @@ class TestHetznerDNSRecordSetInfoJSON(BaseTestModule):
                 'prefix': 'foo',
                 'type': 'TXT',
                 'txt_transformation': 'quoted',
+                'txt_character_encoding': 'octal',
                 '_ansible_remote_tmp': '/tmp/tmp',
                 '_ansible_keep_remote_files': True,
             }, [
@@ -678,19 +679,3 @@ class TestHetznerDNSRecordSetInfoJSON(BaseTestModule):
         assert result['set']['type'] == 'TXT'
         assert result['set']['value'] == [u'"b\\303\\244r \\"with quotes\\" (use \\\\ to escape)"']
         assert 'sets' not in result
-        assert 'deprecations' in result
-        found = False
-        for deprecation in result['deprecations']:
-            if 'collection_name' in deprecation and deprecation['collection_name'] != 'community.dns':
-                continue
-            found = True
-            assert deprecation['msg'] == (
-                'The default of the txt_character_encoding option will change from "octal" to "decimal" in community.dns 3.0.0.'
-                ' This potentially affects you since you use txt_transformation=quoted.'
-                ' You can explicitly set txt_character_encoding to "octal" to keep the current behavior,'
-                ' or "decimal" to already now switch to the new behavior.'
-                ' We recommend switching to the new behavior, and using check/diff mode to figure out potential changes'
-            )
-            assert deprecation['version'] == '3.0.0'
-            assert deprecation.get('date') is None
-        assert found


### PR DESCRIPTION
##### SUMMARY
- Bump version to 3.0.0.
- Remove deprecated features, implement breaking changes.
- Remove `filters` alias of `simple_filters` option for inventory plugins.
- Add new `community.library_inventory_filtering_v1` collection dependency and use it to implement `filters` option for inventory plugins.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various
