### PR TITLE
CI: increase timeout for Quad9 queries

### DIFF
--- a/tests/integration/targets/lookup_lookup/tasks/main.yml
+++ b/tests/integration/targets/lookup_lookup/tasks/main.yml
@@ -8,7 +8,7 @@
     ansible_a: >-
       {{ query('community.dns.lookup', 'ansible.com', type='A') }}
     ansible_aaaa: >-
-      {{ query('community.dns.lookup', 'www.ansible.com', type='AAAA', server='9.9.9.9') }}
+      {{ query('community.dns.lookup', 'www.ansible.com', type='AAAA', server='9.9.9.9', query_timeout=20) }}
     ansible_txt: >-
       {{ query('community.dns.lookup', 'ansible.com', type='TXT', server=['1.1.1.1', '8.8.8.8', 'dns9.quad9.net.']) }}
     ansible_empty: >-

--- a/tests/integration/targets/lookup_lookup_as_dict/tasks/main.yml
+++ b/tests/integration/targets/lookup_lookup_as_dict/tasks/main.yml
@@ -8,7 +8,7 @@
     ansible_a: >-
       {{ query('community.dns.lookup_as_dict', 'ansible.com', type='A') }}
     ansible_aaaa: >-
-      {{ query('community.dns.lookup_as_dict', 'www.ansible.com', type='AAAA', server='9.9.9.9') }}
+      {{ query('community.dns.lookup_as_dict', 'www.ansible.com', type='AAAA', server='9.9.9.9', query_timeout=20) }}
     ansible_txt: >-
       {{ query('community.dns.lookup_as_dict', 'ansible.com', type='TXT', server=['1.1.1.1', '8.8.8.8', 'dns9.quad9.net.']) }}
     ansible_empty: >-


### PR DESCRIPTION
##### SUMMARY
CI has been failing for some days now because of timeouts with 9.9.9.9 (DoH).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
lookup tests
