### PR TITLE
Add reverse_pointer filter and reverse_lookup lookup

### DIFF
--- a/plugins/filter/reverse_pointer.py
+++ b/plugins/filter/reverse_pointer.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020-2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+name: reverse_pointer
+short_description: Convert an IP address into a DNS name for reverse lookup
+version_added: 3.1.0
+description:
+  - Given an IPv4 or IPv6 address, such as V(192.168.1.2), converts it to a DNS name to use for
+    reverse lookups, such as V(2.1.168.192.in-addr.arpa).
+options:
+  _input:
+    description:
+      - The IP address.
+    type: string
+    required: true
+author:
+  - Felix Fontein (@felixfontein)
+seealso:
+  - name: RFC 1035, Section 3.5
+    link: https://www.rfc-editor.org/rfc/rfc1035.html#section-3.5
+    description: Describes C(in-addr.arpa).
+  - name: RFC 3152
+    link: https://www.rfc-editor.org/rfc/rfc3152.html
+    description: Describes C(ip6.arpa).
+"""
+
+EXAMPLES = r"""
+- name: Convert IP address to DNS name for reverse lookup
+  ansible.builtin.set_fact:
+    dns_name: "{{ ip_address | community.dns.reverse_pointer }}"
+    # Should result in '2.1.168.192.in-addr.arpa.'
+  vars:
+    ip_address: 192.168.1.2
+"""
+
+RETURN = r"""
+_value:
+  description: The DNS name.
+  type: string
+"""
+
+
+from ansible.errors import AnsibleFilterError
+from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.six import string_types
+
+from ansible_collections.community.dns.plugins.plugin_utils.ips import assert_requirements_present
+
+try:
+    import ipaddress
+except ImportError:
+    # handled by assert_requirements_present
+    pass
+
+
+def reverse_pointer(ip):
+    assert_requirements_present('community.dns.reverse_pointer', 'filter')
+    if not isinstance(ip, string_types):
+        raise AnsibleFilterError('Input for community.dns.reverse_pointer must be a string')
+    try:
+        ipaddr = ipaddress.ip_address(to_text(ip))
+    except Exception as e:
+        raise AnsibleFilterError('Cannot parse IP address: {error}'.format(error=e))
+    res = ipaddr.reverse_pointer
+    if not res.endswith(u'.'):
+        res += u'.'
+    return res
+
+
+class FilterModule(object):
+    '''Ansible jinja2 filters'''
+
+    def filters(self):
+        return {
+            'reverse_pointer': reverse_pointer,
+        }

--- a/plugins/lookup/reverse_lookup.py
+++ b/plugins/lookup/reverse_lookup.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+name: reverse_lookup
+author: Felix Fontein (@felixfontein)
+short_description: Reverse-look up IP addresses
+version_added: 3.1.0
+requirements:
+    - dnspython >= 1.15.0 (maybe older versions also work)
+description:
+    - Look up hostnames for IP addresses using DNS reverse lookup.
+options:
+    _terms:
+        description:
+            - IP address(es) to look up.
+        type: list
+        elements: str
+        required: true
+    query_retry:
+        description:
+            - Number of retries for DNS query timeouts.
+        type: int
+        default: 3
+    query_timeout:
+        description:
+            - Timeout per DNS query in seconds.
+        type: float
+        default: 10
+    server:
+        description:
+            - The DNS server(s) to use to look up the result. Must be a list of one or more IP addresses.
+            - By default, the system's standard resolver is used.
+        type: list
+        elements: str
+    servfail_retries:
+        description:
+            - How often to retry on SERVFAIL errors.
+        type: int
+        default: 0
+notes:
+    - Note that when using this lookup plugin with V(lookup(\)), and the result is a one-element list,
+      Ansible simply returns the one element not as a list. Since this behavior is surprising and
+      can cause problems, it is better to use V(query(\)) instead of V(lookup(\)). See the examples
+      and also R(Forcing lookups to return lists, query) in the Ansible documentation.
+'''
+
+EXAMPLES = """
+- name: Look up hostname of IPv4 address
+  ansible.builtin.debug:
+    msg: "{{ query('community.dns.reverse_lookup', '192.168.1.1') }}"
+
+- name: Look up hostname of IPv6 address
+  ansible.builtin.debug:
+    msg: "{{ query('community.dns.reverse_lookup', '1:2:3::4') }}"
+"""
+
+RETURN = """
+_result:
+    description:
+        - The hostname(s) returned for the queried IP addresses.
+        - If multiple IP addresses are queried in O(_terms), the resulting lists have been concatenated.
+    type: list
+    elements: str
+    sample:
+        - example.com
+        - example.org
+"""
+
+from ansible.errors import AnsibleLookupError
+from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.common.text.converters import to_text
+
+from ansible_collections.community.dns.plugins.module_utils.ips import (
+    is_ip_address,
+)
+
+from ansible_collections.community.dns.plugins.module_utils.resolver import (
+    SimpleResolver,
+)
+
+from ansible_collections.community.dns.plugins.plugin_utils.ips import (
+    assert_requirements_present as assert_requirements_present_ipaddress,
+)
+
+from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
+    assert_requirements_present as assert_requirements_present_dnspython,
+    guarded_run,
+)
+
+try:
+    import dns.resolver
+except ImportError:
+    # handled by assert_requirements_present_dnspython
+    pass
+
+try:
+    import ipaddress
+except ImportError:
+    # handled by assert_requirements_present
+    pass
+
+
+class LookupModule(LookupBase):
+    @staticmethod
+    def _resolve(resolver, name, rdtype, server_addresses):
+        def callback():
+            try:
+                rrset = resolver.resolve(
+                    name,
+                    rdtype=rdtype,
+                    server_addresses=server_addresses,
+                    nxdomain_is_empty=True,
+                    target_can_be_relative=False,
+                    search=False,
+                )
+                if not rrset:
+                    return []
+                return [to_text(data) for data in rrset]
+            except dns.resolver.NXDOMAIN:
+                raise AnsibleLookupError('Got NXDOMAIN when querying {name}'.format(name=name))
+
+        return guarded_run(
+            callback,
+            error_class=AnsibleLookupError,
+            server=name,
+        )
+
+    def run(self, terms, variables=None, **kwargs):
+        assert_requirements_present_dnspython('community.dns.reverse_lookup', 'lookup')
+        assert_requirements_present_ipaddress('community.dns.reverse_lookup', 'lookup')
+
+        self.set_options(var_options=variables, direct=kwargs)
+
+        resolver = SimpleResolver(
+            timeout=self.get_option('query_timeout'),
+            timeout_retries=self.get_option('query_retry'),
+            servfail_retries=self.get_option('servfail_retries'),
+        )
+
+        server_addresses = None
+        if self.get_option('server'):
+            server_addresses = []
+            for server in self.get_option('server'):
+                if is_ip_address(server):
+                    server_addresses.append(server)
+                    continue
+                else:
+                    server_addresses.extend(guarded_run(
+                        lambda: resolver.resolve_addresses(server),
+                        error_class=AnsibleLookupError,
+                        server=server,
+                    ))
+
+        ip_adresses = []
+        for ip_address in terms:
+            try:
+                ipaddr = ipaddress.ip_address(to_text(ip_address))
+                name = ipaddr.reverse_pointer
+                if not name.endswith(u'.'):
+                    name += u'.'
+                ip_adresses.append(name)
+            except Exception as e:
+                raise AnsibleLookupError('Cannot parse IP address {ip!r}: {error}'.format(ip=ip_address, error=e))
+
+        result = []
+        for name in ip_adresses:
+            result.extend(self._resolve(resolver, name, dns.rdatatype.PTR, server_addresses))
+        return result

--- a/tests/integration/targets/filter_reverse_pointer/aliases
+++ b/tests/integration/targets/filter_reverse_pointer/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+shippable/posix/group1

--- a/tests/integration/targets/filter_reverse_pointer/tasks/main.yml
+++ b/tests/integration/targets/filter_reverse_pointer/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Compute reverse pointer
+  ansible.builtin.set_fact:
+    reverse_ipv4: >-
+      {{ '192.168.1.2' | community.dns.reverse_pointer }}
+    reverse_ipv6: >-
+      {{ 'a::B' | community.dns.reverse_pointer }}
+
+- name: Check results
+  assert:
+    that:
+      - reverse_ipv4 == '2.1.168.192.in-addr.arpa.'
+      - reverse_ipv6 == 'b.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.a.0.0.0.ip6.arpa.'
+
+- name: Process invalid IP address
+  ansible.builtin.set_fact:
+    reverse_nope: >-
+      {{ 'foo.com' | community.dns.reverse_pointer }}
+  ignore_errors: true
+  register: invalid_ip
+
+- name: Process non-string
+  ansible.builtin.set_fact:
+    reverse_nope: >-
+      {{ 42 | community.dns.reverse_pointer }}
+  ignore_errors: true
+  register: non_string
+
+- name: Check results
+  assert:
+    that:
+      - invalid_ip is failed
+      - >-
+        "Cannot parse IP address: 'foo.com' does not appear to be an IPv4 or IPv6 address" in invalid_ip.msg
+      - non_string is failed
+      - >-
+        "Input for community.dns.reverse_pointer must be a string" in non_string.msg

--- a/tests/integration/targets/lookup_reverse_lookup/aliases
+++ b/tests/integration/targets/lookup_reverse_lookup/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+shippable/posix/group1

--- a/tests/integration/targets/lookup_reverse_lookup/tasks/main.yml
+++ b/tests/integration/targets/lookup_reverse_lookup/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Look up some records
+  ansible.builtin.set_fact:
+    ansible_a: >-
+      {{ query('community.dns.reverse_lookup', '9.9.9.9') }}
+    ansible_aaaa: >-
+      {{ query('community.dns.reverse_lookup', '2620:fe::fe') }}
+    ansible_both: >-
+      {{ query('community.dns.reverse_lookup', '9.9.9.9', '2620:fe::fe') }}
+
+- name: Check results
+  assert:
+    that:
+      - ansible_a == ['dns9.quad9.net.']
+      - ansible_aaaa == ['dns.quad9.net.']
+      - ansible_both == ['dns9.quad9.net.', 'dns.quad9.net.']


### PR DESCRIPTION
##### SUMMARY
Add plugins for helping with reverse lookups:
1. A filter to convert IP addresses into DNS names for using with regular lookup plugins;
2. A reverse lookup plugin which does the whole thing in one step.

Fixes #227.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
reverse_pointer filter
