### PR TITLE
Add 'idempotent' attribute

### DIFF
--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -20,7 +20,7 @@ attributes:
     description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
   idempotent:
     description:
-      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
       - This assumes that the system controlled/queried by the module has not changed in a relevant way.
 """
 

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -25,6 +25,16 @@ attributes:
 """
 
     # Should be used together with the standard fragment
+    IDEMPOTENT_NOT_MODIFY_STATE = r"""
+options: {}
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
+"""
+
+    # Should be used together with the standard fragment
     INFO_MODULE = r'''
 options: {}
 attributes:

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -18,6 +18,10 @@ attributes:
     description: Can run in C(check_mode) and return changed status prediction without modifying target.
   diff_mode:
     description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+  idempotent:
+    description:
+      - When run twice in a row with the same arguments, the second invocation indicates no change.
+      - This assumes that the system controlled/queried by the module has not changed in a relevant way.
 """
 
     # Should be used together with the standard fragment

--- a/plugins/doc_fragments/module_record.py
+++ b/plugins/doc_fragments/module_record.py
@@ -22,6 +22,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  idempotent:
+    support: full
 options:
   state:
     description:

--- a/plugins/doc_fragments/module_record_info.py
+++ b/plugins/doc_fragments/module_record_info.py
@@ -18,8 +18,6 @@ class ModuleDocFragment(object):
 attributes:
   idempotent:
     support: full
-    details:
-      - This action does not modify state.
 options:
   what:
     description:

--- a/plugins/doc_fragments/module_record_info.py
+++ b/plugins/doc_fragments/module_record_info.py
@@ -15,6 +15,11 @@ class ModuleDocFragment(object):
     # NOTE: This document fragment needs to be augmented by ZONE_ID_TYPE in a provider document fragment.
     #       The ZONE_ID_TYPE fragment will provide `choices` for the options.type entry.
     DOCUMENTATION = r"""
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 options:
   what:
     description:

--- a/plugins/doc_fragments/module_record_set.py
+++ b/plugins/doc_fragments/module_record_set.py
@@ -20,6 +20,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  idempotent:
+    support: full
 options:
   state:
     description:

--- a/plugins/doc_fragments/module_record_set_info.py
+++ b/plugins/doc_fragments/module_record_set_info.py
@@ -18,8 +18,6 @@ class ModuleDocFragment(object):
 attributes:
   idempotent:
     support: full
-    details:
-      - This action does not modify state.
 options:
   what:
     description:

--- a/plugins/doc_fragments/module_record_set_info.py
+++ b/plugins/doc_fragments/module_record_set_info.py
@@ -15,6 +15,11 @@ class ModuleDocFragment(object):
     # NOTE: This document fragment needs to be augmented by ZONE_ID_TYPE in a provider document fragment.
     #       The ZONE_ID_TYPE fragment will provide `choices` for the options.type entry.
     DOCUMENTATION = r"""
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 options:
   what:
     description:

--- a/plugins/doc_fragments/module_record_sets.py
+++ b/plugins/doc_fragments/module_record_sets.py
@@ -22,6 +22,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  idempotent:
+    support: full
 options:
   zone_name:
     description:

--- a/plugins/doc_fragments/module_zone_info.py
+++ b/plugins/doc_fragments/module_zone_info.py
@@ -15,8 +15,6 @@ class ModuleDocFragment(object):
 attributes:
   idempotent:
     support: full
-    details:
-      - This action does not modify state.
 options:
   zone_name:
     description:

--- a/plugins/doc_fragments/module_zone_info.py
+++ b/plugins/doc_fragments/module_zone_info.py
@@ -12,6 +12,11 @@ class ModuleDocFragment(object):
 
     # Standard files documentation fragment
     DOCUMENTATION = r"""
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 options:
   zone_name:
     description:

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hetzner
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hetzner
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -25,6 +25,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hetzner
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -28,6 +28,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hosttech
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -30,6 +30,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hosttech
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -25,6 +25,7 @@ extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.actiongroup_hosttech
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 
 attributes:
   action_group:

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -20,6 +20,11 @@ extends_documentation_fragment:
   - community.dns.attributes.info_module
 author:
   - Felix Fontein (@felixfontein)
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 options:
   name:
     description:

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -18,13 +18,9 @@ description:
 extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 author:
   - Felix Fontein (@felixfontein)
-attributes:
-  idempotent:
-    support: full
-    details:
-      - This action does not modify state.
 options:
   name:
     description:

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -19,13 +19,9 @@ description:
 extends_documentation_fragment:
   - community.dns.attributes
   - community.dns.attributes.info_module
+  - community.dns.attributes.idempotent_not_modify_state
 author:
   - Felix Fontein (@felixfontein)
-attributes:
-  idempotent:
-    support: full
-    details:
-      - This action does not modify state.
 options:
   name:
     description:

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -21,6 +21,11 @@ extends_documentation_fragment:
   - community.dns.attributes.info_module
 author:
   - Felix Fontein (@felixfontein)
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 options:
   name:
     description:

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -27,6 +27,10 @@ attributes:
     support: N/A
     details:
       - This action does not modify state.
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
 author:
   - Felix Fontein (@felixfontein)
 options:

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -17,6 +17,7 @@ description:
   - Wait for TXT entries with specific values to show up on B(all) authoritative nameservers for the DNS name.
 extends_documentation_fragment:
   - community.dns.attributes
+  - community.dns.attributes.idempotent_not_modify_state
 attributes:
   check_mode:
     support: full
@@ -25,10 +26,6 @@ attributes:
     version_added: 2.4.0
   diff_mode:
     support: N/A
-    details:
-      - This action does not modify state.
-  idempotent:
-    support: full
     details:
       - This action does not modify state.
 author:


### PR DESCRIPTION
##### SUMMARY
Adds a new attribute `idempotent` for module documentation, which states whether (resp. under which circumstances) the module is idempotent.

Related PRs:
- https://github.com/ansible-collections/community.crypto/pull/833
- https://github.com/ansible-collections/community.docker/pull/1022
- https://github.com/ansible-collections/community.hrobot/pull/132
- https://github.com/ansible-collections/community.routeros/pull/337
- https://github.com/ansible-collections/community.sops/pull/217

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module documentation
