### PR TITLE
Add code formatting (Python 3 only), type checking, and other checks

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -1,0 +1,57 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: nox
+'on':
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run CI once per day (at 04:30 UTC)
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  nox:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ansible_collections/community/dns
+    name: "Run nox"
+    steps:
+      - name: Check out collection
+        uses: actions/checkout@v4
+        with:
+          path: ansible_collections/community/dns
+          persist-credentials: false
+      - name: Check out community.internal_test_tools
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-collections/community.internal_test_tools
+          ref: main
+          path: ansible_collections/community/internal_test_tools
+          persist-credentials: false
+      - name: Check out community.library_inventory_filtering
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-collections/community.library_inventory_filtering
+          ref: stable-1
+          path: ansible_collections/community/library_inventory_filtering_v1
+          persist-credentials: false
+      - name: Setup nox
+        uses: wntrblm/nox@2024.10.09
+        with:
+          python-versions: "3.13"
+      - name: Set up nox environments
+        run: |
+          nox -v -e lint --install-only
+      - name: "Run nox"
+        run: |
+          nox -v -e lint --reuse-existing-virtualenvs --no-install

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,6 +6,37 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Running tests
 
+## Prerequisites
+
+For testing, you need to check out the collection repository in a specific path structure: the checkout needs to be in `ansible_collections/community/dns`. This is both a requirement of `ansible-test` and for the current implementation of `pylint` and `mypy` code checks.
+
+You also need the collection's dependency, `community.library_inventory_filtering_v1`, installed in the same tree structure, i.e. in `ansible_collections/community/library_inventory_filtering_v1`. Note that the repository (https://github.com/ansible-collections/community.library_inventory_filtering/) does not have the `_v1` suffix in its name.
+
+For **unit tests** and the `nox`-based **sanity tests**, you also need `community.internal_test_tools` installed in the same tree, at `ansible_collections/community/internal_test_tools`.
+
+Finally, for the **integration tests**, you also need `community.general` installed in the same tree, at `ansible_collections/community/general`.
+
+## Running ansible-test based sanity tests
+
+To run all sanity tests: `ansible-test sanity --docker -v`
+
+## Running nox based sanity tests and code formatting
+
+Run `nox -e lint` to run all sanity tests, including code formatting.
+
+You can also run more specific tests:
+* `nox -e formatters` to run the code formatters;
+* `nox -e codeqa` to run code QA linters (flake8 and pylint);
+* `nox -e typing` to run type checking for Python 3+ code (mypy).
+
+You can use `-Re` instead of `-e` to re-run tests; that will re-use the created virtual environments and avoid re-installation of the requirements. From time to time you should use `-e` again to make sure you have an updated virtual environment. For example, if you notice a discrepancy between CI and running tests locally, using `-e` might be a good idea.
+
+## Running unit tests
+
+To run all unit tests for all supported (by your ansible-core version) Python versions, run `ansible-test units --docker -v`.
+
+To run all unit tests for a specific Python version (this is usually sufficient and much faster): `ansible-test units --docker -v --python 3.13`
+
 ## HostTech DNS modules
 
 The CI (based on GitHub Actions) does not run integration tests for the HostTech modules, because they need access to HostTech API credentials. If you have some, copy [`tests/integration/integration_config.yml.hosttech-template`](https://github.com/ansible-collections/community.dns/blob/main/tests/integration/integration_config.yml.hosttech-template) to `integration_config.yml` in the same directory, and insert username, key, a test zone (`domain.ch`) and test record (`foo.domain.ch`). Then run `ansible-test integration --allow-unsupported hosttech`. Please note that the test record will be deleted, (re-)created, and finally deleted, so do not use any record you actually need!

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,224 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Felix Fontein <felix@fontein.de>
+
+import contextlib
+import os
+
+import nox
+
+
+IN_CI = "GITHUB_ACTIONS" in os.environ
+ALLOW_EDITABLE = os.environ.get("ALLOW_EDITABLE", str(not IN_CI)).lower() in (
+    "1",
+    "true",
+)
+CODE_FILES = [
+    "plugins",
+    "tests/unit",
+]
+
+COLLECTION_NAME = "community.dns"
+
+PYTHON_2_COMPATIBILITY = [
+    "plugins/modules/",
+    "plugins/module_utils/",
+    "tests/unit/plugins/modules/",
+    "tests/unit/plugins/module_utils/",
+]
+
+# Always install latest pip version
+os.environ["VIRTUALENV_DOWNLOAD"] = "1"
+
+# Default session is 'lint'
+nox.options.sessions = "lint"
+
+
+def install(session: nox.Session, *args, editable=False, **kwargs):
+    # nox --no-venv
+    if isinstance(session.virtualenv, nox.virtualenv.PassthroughEnv):
+        session.warn(f"No venv. Skipping installation of {args}")
+        return
+    # Don't install in editable mode in CI or if it's explicitly disabled.
+    # This ensures that the wheel contains all of the correct files.
+    if editable and ALLOW_EDITABLE:
+        args = ("-e", *args)
+    session.install(*args, "-U", **kwargs)
+
+
+@contextlib.contextmanager
+def ansible_collection_root():
+    cwd = os.getcwd()
+    root = os.path.normpath(os.path.join(cwd, "..", "..", ".."))
+    try:
+        os.chdir(root)
+        yield root, os.path.relpath(cwd, root)
+    finally:
+        os.chdir(cwd)
+
+
+def prefix_paths(paths: list[str], /, prefix: str) -> list[str]:
+    return [os.path.join(prefix, path) for path in paths]
+
+
+def match_path(path: str, is_file: bool, paths: list[str]) -> bool:
+    for check in paths:
+        if check == path:
+            return True
+        if not is_file:
+            if not check.endswith("/"):
+                check += "/"
+            if path.startswith(check):
+                return True
+    return False
+
+
+def restrict_paths(paths: list[str], restrict: list[str]) -> list[str]:
+    result = []
+    for path in paths:
+        is_file = os.path.isfile(path)
+        if not is_file and not path.endswith("/"):
+            path += "/"
+        if not match_path(path, is_file, restrict):
+            if not is_file:
+                for check in restrict:
+                    if check.startswith(path):
+                        result.append(check)
+            continue
+        result.append(path)
+    return result
+
+
+def remove_paths(
+    paths: list[str], remove: list[str], extensions: list[str] | None
+) -> list[str]:
+    result = []
+    for path in paths:
+        is_file = os.path.isfile(path)
+        if not is_file and not path.endswith("/"):
+            path += "/"
+        if match_path(path, is_file, remove):
+            continue
+        if not is_file and any(check.startswith(path) for check in remove):
+            for root, dirs, files in os.walk(path, topdown=True):
+                if not root.endswith("/"):
+                    root += "/"
+                if match_path(root, False, remove):
+                    continue
+                if all(not check.startswith(root) for check in remove):
+                    dirs[:] = []
+                    result.append(root)
+                    continue
+                for file in files:
+                    if extensions and os.path.splitext(file)[1] not in extensions:
+                        continue
+                    filepath = os.path.normpath(os.path.join(root, file))
+                    if not match_path(filepath, True, remove):
+                        result.append(filepath)
+                for dir in list(dirs):
+                    dirpath = os.path.normpath(os.path.join(root, dir))
+                    if match_path(dirpath, False, remove):
+                        dirs.remove(dir)
+                        continue
+            continue
+        result.append(path)
+    return result
+
+
+def filter_paths(
+    paths: list[str],
+    /,
+    remove: list[str] | None = None,
+    restrict: list[str] | None = None,
+    extensions: list[str] | None = None
+) -> list[str]:
+    if restrict:
+        paths = restrict_paths(paths, restrict)
+    if remove:
+        paths = remove_paths(paths, remove, extensions)
+    return paths
+
+
+@nox.session
+def lint(session: nox.Session):
+    session.notify("formatters")
+    session.notify("codeqa")
+    session.notify("typing")
+
+
+@nox.session
+def formatters(session: nox.Session):
+    install(session, "-r", "tests/nox-requirements-formatters.txt")
+    posargs = list(session.posargs)
+    if IN_CI:
+        posargs.append("--check")
+    session.run(
+        "isort",
+        *posargs,
+        "--settings-file",
+        "tests/nox-config-isort.cfg",
+        *CODE_FILES,
+        "noxfile.py",
+    )
+    return  # TODO: remove once reformatting
+    # The last version of black that supports Python 2.7, 21.12b0, does not run on Python 3.13 -.-
+    # Hence we have to restrict to Python 3 files for black
+    py3_paths = filter_paths(  # pylint: disable=unreachable
+        CODE_FILES + ["noxfile.py"], remove=PYTHON_2_COMPATIBILITY, extensions=[".py"]
+    )
+    if py3_paths:
+        session.run(
+            "black", "--config", "tests/nox-config-black.toml", *posargs, *py3_paths
+        )
+
+
+@nox.session
+def codeqa(session: nox.Session):
+    install(session, "-r", "tests/nox-requirements-codeqa.txt")
+    session.run(
+        "flake8",
+        "--config",
+        "tests/nox-config-flake8.ini",
+        *CODE_FILES,
+        "noxfile.py",
+        *session.posargs,
+    )
+    py2_paths = filter_paths(
+        CODE_FILES, restrict=PYTHON_2_COMPATIBILITY, extensions=[".py"]
+    )
+    py3_paths = filter_paths(
+        CODE_FILES, remove=PYTHON_2_COMPATIBILITY, extensions=[".py"]
+    )
+    with ansible_collection_root() as (root, prefix):
+        if py2_paths:
+            session.run(
+                "pylint",
+                "--rcfile",
+                os.path.join(root, prefix, "tests/nox-config-pylint-py2.rc"),
+                "--source-roots",
+                root,
+                *prefix_paths(py2_paths, prefix=prefix),
+            )
+        if py3_paths:
+            session.run(
+                "pylint",
+                "--rcfile",
+                os.path.join(root, prefix, "tests/nox-config-pylint.rc"),
+                "--source-roots",
+                root,
+                *prefix_paths(py3_paths, prefix=prefix),
+            )
+
+
+@nox.session
+def typing(session: nox.Session):
+    install(session, "-r", "tests/nox-requirements-typing.txt")
+    with ansible_collection_root() as (root, prefix):
+        session.run(
+            "mypy",
+            "--config-file",
+            os.path.join(root, prefix, "tests/nox-config-mypy.ini"),
+            "--explicit-package-bases",
+            *prefix_paths(CODE_FILES, prefix=prefix),
+            env={"MYPYPATH": root},
+        )

--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/filters.py
+++ b/plugins/doc_fragments/filters.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/hetzner.py
+++ b/plugins/doc_fragments/hetzner.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/hosttech.py
+++ b/plugins/doc_fragments/hosttech.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/inventory_records.py
+++ b/plugins/doc_fragments/inventory_records.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_record.py
+++ b/plugins/doc_fragments/module_record.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_record_info.py
+++ b/plugins/doc_fragments/module_record_info.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_record_set.py
+++ b/plugins/doc_fragments/module_record_set.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_record_set_info.py
+++ b/plugins/doc_fragments/module_record_set_info.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_record_sets.py
+++ b/plugins/doc_fragments/module_record_sets.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/module_zone_info.py
+++ b/plugins/doc_fragments/module_zone_info.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/doc_fragments/options.py
+++ b/plugins/doc_fragments/options.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/filter/domain_suffix.py
+++ b/plugins/filter/domain_suffix.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
-from ansible_collections.community.dns.plugins.plugin_utils.public_suffix import PUBLIC_SUFFIX_LIST
+from ansible_collections.community.dns.plugins.plugin_utils.public_suffix import (
+    PUBLIC_SUFFIX_LIST,
+)
 
 
 def _remove_suffix(dns_name, suffix, keep_trailing_period):

--- a/plugins/filter/reverse_pointer.py
+++ b/plugins/filter/reverse_pointer.py
@@ -48,8 +48,10 @@ _value:
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_text
+from ansible_collections.community.dns.plugins.plugin_utils.ips import (
+    assert_requirements_present,
+)
 
-from ansible_collections.community.dns.plugins.plugin_utils.ips import assert_requirements_present
 
 try:
     import ipaddress

--- a/plugins/filter/txt.py
+++ b/plugins/filter/txt.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.txt import (
     decode_txt_value,
     encode_txt_value,

--- a/plugins/inventory/hetzner_dns_records.py
+++ b/plugins/inventory/hetzner_dns_records.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r"""
 name: hetzner_dns_records
 
@@ -73,21 +74,16 @@ hetzner_token: >-
 """
 
 
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    OpenURLHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
     create_hetzner_api,
     create_hetzner_provider_information,
 )
-
-from ansible_collections.community.dns.plugins.plugin_utils.templated_options import (
-    TemplatedOptionProvider,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.http import OpenURLHelper
 from ansible_collections.community.dns.plugins.plugin_utils.inventory.records import (
     RecordsInventoryModule,
+)
+from ansible_collections.community.dns.plugins.plugin_utils.templated_options import (
+    TemplatedOptionProvider,
 )
 
 

--- a/plugins/inventory/hosttech_dns_records.py
+++ b/plugins/inventory/hosttech_dns_records.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r"""
 name: hosttech_dns_records
 
@@ -79,21 +80,16 @@ hosttech_token: >-
   {{ (lookup('community.sops.sops', 'keys/hosttech.sops.yml') | from_yaml).hosttech_dns_token }}
 """
 
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    OpenURLHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
     create_hosttech_api,
     create_hosttech_provider_information,
 )
-
-from ansible_collections.community.dns.plugins.plugin_utils.templated_options import (
-    TemplatedOptionProvider,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.http import OpenURLHelper
 from ansible_collections.community.dns.plugins.plugin_utils.inventory.records import (
     RecordsInventoryModule,
+)
+from ansible_collections.community.dns.plugins.plugin_utils.templated_options import (
+    TemplatedOptionProvider,
 )
 
 

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r"""
 name: lookup
 author: Felix Fontein (@felixfontein)
@@ -127,29 +128,25 @@ _result:
 """
 
 from ansible.errors import AnsibleLookupError
-from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_text
-
-from ansible_collections.community.dns.plugins.module_utils.ips import (
-    is_ip_address,
-)
-
+from ansible.plugins.lookup import LookupBase
 from ansible_collections.community.dns.plugins.module_utils.dnspython_records import (
     NAME_TO_RDTYPE,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.ips import is_ip_address
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     SimpleResolver,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.ips import (
     assert_requirements_present as assert_requirements_present_ipaddress,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     assert_requirements_present as assert_requirements_present_dnspython,
+)
+from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     guarded_run,
 )
+
 
 try:
     import dns.resolver

--- a/plugins/lookup/lookup_as_dict.py
+++ b/plugins/lookup/lookup_as_dict.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r"""
 name: lookup_as_dict
 author: Felix Fontein (@felixfontein)
@@ -417,28 +418,24 @@ _result:
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-
-from ansible_collections.community.dns.plugins.module_utils.ips import (
-    is_ip_address,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.dnspython_records import (
     NAME_TO_RDTYPE,
     convert_rdata_to_dict,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.ips import is_ip_address
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     SimpleResolver,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.ips import (
     assert_requirements_present as assert_requirements_present_ipaddress,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     assert_requirements_present as assert_requirements_present_dnspython,
+)
+from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     guarded_run,
 )
+
 
 try:
     import dns.resolver

--- a/plugins/lookup/reverse_lookup.py
+++ b/plugins/lookup/reverse_lookup.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r"""
 name: reverse_lookup
 author: Felix Fontein (@felixfontein)
@@ -72,25 +73,22 @@ _result:
 """
 
 from ansible.errors import AnsibleLookupError
-from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_text
-
-from ansible_collections.community.dns.plugins.module_utils.ips import (
-    is_ip_address,
-)
-
+from ansible.plugins.lookup import LookupBase
+from ansible_collections.community.dns.plugins.module_utils.ips import is_ip_address
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     SimpleResolver,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.ips import (
     assert_requirements_present as assert_requirements_present_ipaddress,
 )
-
 from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     assert_requirements_present as assert_requirements_present_dnspython,
+)
+from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     guarded_run,
 )
+
 
 try:
     import dns.resolver

--- a/plugins/module_utils/argspec.py
+++ b/plugins/module_utils/argspec.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/module_utils/conversion/base.py
+++ b/plugins/module_utils/conversion/base.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/module_utils/conversion/converter.py
+++ b/plugins/module_utils/conversion/converter.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -12,19 +14,14 @@ import warnings
 
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import raise_from
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.txt import (
     decode_txt_value,
     encode_txt_value,
 )
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 
 
 class RecordConverter(object):

--- a/plugins/module_utils/conversion/txt.py
+++ b/plugins/module_utils/conversion/txt.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -12,7 +14,6 @@ import sys
 import warnings
 
 from ansible.module_utils.common.text.converters import to_bytes, to_text
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )

--- a/plugins/module_utils/dnspython_records.py
+++ b/plugins/module_utils/dnspython_records.py
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -14,6 +16,7 @@ import base64
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.six import binary_type
+
 
 NAME_TO_RDTYPE = {}
 RDTYPE_TO_NAME = {}

--- a/plugins/module_utils/hetzner/api.py
+++ b/plugins/module_utils/hetzner/api.py
@@ -5,37 +5,27 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 from ansible.module_utils.basic import env_fallback
-
-from ansible_collections.community.dns.plugins.module_utils.argspec import (
-    ArgumentSpec,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.argspec import ArgumentSpec
 from ansible_collections.community.dns.plugins.module_utils.json_api_helper import (
-    JSONAPIHelper,
     ERROR_CODES,
     UNKNOWN_ERROR,
+    JSONAPIHelper,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.provider import (
     ProviderInformation,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
-from ansible_collections.community.dns.plugins.module_utils.zone import (
-    DNSZone,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
+from ansible_collections.community.dns.plugins.module_utils.zone import DNSZone
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
     NOT_PROVIDED,
+    DNSAPIError,
     ZoneRecordAPI,
     filter_records,
 )

--- a/plugins/module_utils/hosttech/api.py
+++ b/plugins/module_utils/hosttech/api.py
@@ -4,32 +4,25 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
-from ansible_collections.community.dns.plugins.module_utils.argspec import (
-    ArgumentSpec,
+from ansible_collections.community.dns.plugins.module_utils.argspec import ArgumentSpec
+from ansible_collections.community.dns.plugins.module_utils.hosttech.json_api import (
+    HostTechJSONAPI,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.provider import (
-    ProviderInformation,
-)
-
-from ansible_collections.community.dns.plugins.module_utils.wsdl import (
-    HAS_LXML_ETREE,
-)
-
-from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.wsdl_api import (
     HostTechWSDLAPI,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.hosttech.json_api import (
-    HostTechJSONAPI,
+from ansible_collections.community.dns.plugins.module_utils.provider import (
+    ProviderInformation,
+)
+from ansible_collections.community.dns.plugins.module_utils.wsdl import HAS_LXML_ETREE
+from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
+    DNSAPIError,
 )
 
 

--- a/plugins/module_utils/hosttech/json_api.py
+++ b/plugins/module_utils/hosttech/json_api.py
@@ -6,26 +6,23 @@
 
 # The API documentation can be found here: https://api.ns1.hosttech.eu/api/documentation/
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 from ansible_collections.community.dns.plugins.module_utils.json_api_helper import (
     JSONAPIHelper,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 from ansible_collections.community.dns.plugins.module_utils.zone import (
     DNSZone,
     DNSZoneWithRecords,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
     NOT_PROVIDED,
+    DNSAPIError,
     ZoneRecordAPI,
     filter_records,
 )

--- a/plugins/module_utils/hosttech/wsdl_api.py
+++ b/plugins/module_utils/hosttech/wsdl_api.py
@@ -4,32 +4,28 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
-from ansible.module_utils.six import raise_from
 from ansible.module_utils.common.text.converters import to_native
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
+from ansible.module_utils.six import raise_from
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 from ansible_collections.community.dns.plugins.module_utils.wsdl import (
+    Composer,
     WSDLError,
     WSDLNetworkError,
-    Composer,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone import (
     DNSZone,
     DNSZoneWithRecords,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
     NOT_PROVIDED,
+    DNSAPIAuthenticationError,
+    DNSAPIError,
     ZoneRecordAPI,
     filter_records,
 )

--- a/plugins/module_utils/http.py
+++ b/plugins/module_utils/http.py
@@ -14,7 +14,7 @@ from ansible.module_utils import six
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import PY3
 from ansible.module_utils.urls import fetch_url, open_url, NoSSLError, ConnectionError
-import ansible.module_utils.six.moves.urllib.error as urllib_error
+import ansible.module_utils.six.moves.urllib.error as urllib_error  # pylint: disable=import-error
 
 
 class NetworkError(Exception):

--- a/plugins/module_utils/http.py
+++ b/plugins/module_utils/http.py
@@ -4,17 +4,19 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import abc
 
+import ansible.module_utils.six.moves.urllib.error as urllib_error  # pylint: disable=import-error
 from ansible.module_utils import six
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import PY3
-from ansible.module_utils.urls import fetch_url, open_url, NoSSLError, ConnectionError
-import ansible.module_utils.six.moves.urllib.error as urllib_error  # pylint: disable=import-error
+from ansible.module_utils.urls import ConnectionError, NoSSLError, fetch_url, open_url
 
 
 class NetworkError(Exception):

--- a/plugins/module_utils/ips.py
+++ b/plugins/module_utils/ips.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     IPADDRESS_IMPORT_EXC = traceback.format_exc()
 else:
-    IPADDRESS_IMPORT_EXC = None
+    IPADDRESS_IMPORT_EXC = None  # type: ignore  # TODO
 
 
 def is_ip_address(server):

--- a/plugins/module_utils/ips.py
+++ b/plugins/module_utils/ips.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -12,6 +14,7 @@ import traceback
 
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_text
+
 
 try:
     import ipaddress

--- a/plugins/module_utils/json_api_helper.py
+++ b/plugins/module_utils/json_api_helper.py
@@ -5,20 +5,24 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import json
 import time
 
-from ansible.module_utils.six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 from ansible.module_utils.common.text.converters import to_native
-
-from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
+from ansible.module_utils.six.moves.urllib.parse import (  # pylint: disable=import-error
+    urlencode,
 )
+from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
+    DNSAPIAuthenticationError,
+    DNSAPIError,
+)
+
 
 ERROR_CODES = {
     200: "Successful response",

--- a/plugins/module_utils/json_api_helper.py
+++ b/plugins/module_utils/json_api_helper.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 import json
 import time
 
-from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (

--- a/plugins/module_utils/module/_utils.py
+++ b/plugins/module_utils/module/_utils.py
@@ -6,16 +6,17 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 from ansible_collections.community.dns.plugins.module_utils.names import (
-    split_into_labels,
     join_labels,
     normalize_label,
+    split_into_labels,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )

--- a/plugins/module_utils/module/record.py
+++ b/plugins/module_utils/module/record.py
@@ -6,47 +6,40 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ArgumentSpec,
     ModuleOptionProvider,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_record_transformation_argspec,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.record import (
     DNSRecord,
     format_record_for_output,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
     NOT_PROVIDED,
+    DNSAPIAuthenticationError,
+    DNSAPIError,
     filter_records,
 )
 
-from ._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
+from ._utils import get_prefix, normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/module/record_info.py
+++ b/plugins/module_utils/module/record_info.py
@@ -6,45 +6,38 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ArgumentSpec,
     ModuleOptionProvider,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_record_transformation_argspec,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.record import (
     format_record_for_output,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
     NOT_PROVIDED,
+    DNSAPIAuthenticationError,
+    DNSAPIError,
 )
 
-from ._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
+from ._utils import get_prefix, normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/module/record_set.py
+++ b/plugins/module_utils/module/record_set.py
@@ -6,52 +6,44 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ArgumentSpec,
     ModuleOptionProvider,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_bulk_operations_argspec,
     create_record_transformation_argspec,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.record import (
     DNSRecord,
     format_records_for_output,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
     NOT_PROVIDED,
+    DNSAPIAuthenticationError,
+    DNSAPIError,
     filter_records,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_helpers import (
     bulk_apply_changes,
 )
 
-from ._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
+from ._utils import get_prefix, normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/module/record_set_info.py
+++ b/plugins/module_utils/module/record_set_info.py
@@ -6,45 +6,38 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ArgumentSpec,
     ModuleOptionProvider,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_record_transformation_argspec,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.record import (
     format_records_for_output,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
     NOT_PROVIDED,
+    DNSAPIAuthenticationError,
+    DNSAPIError,
 )
 
-from ._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
+from ._utils import get_prefix, normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/module/record_sets.py
+++ b/plugins/module_utils/module/record_sets.py
@@ -6,50 +6,42 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ArgumentSpec,
     ModuleOptionProvider,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.options import (
     create_bulk_operations_argspec,
     create_record_transformation_argspec,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.record import (
     DNSRecord,
     format_records_for_output,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
     DNSAPIAuthenticationError,
+    DNSAPIError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.zone_record_helpers import (
     bulk_apply_changes,
 )
 
-from ._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
+from ._utils import get_prefix, normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/module/zone_info.py
+++ b/plugins/module_utils/module/zone_info.py
@@ -6,26 +6,22 @@
 
 # This module_utils is PRIVATE and should only be used by this collection. Breaking changes can occur any time.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import traceback
 
 from ansible.module_utils.common.text.converters import to_text
-
-from ansible_collections.community.dns.plugins.module_utils.argspec import (
-    ArgumentSpec,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.argspec import ArgumentSpec
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
     DNSAPIAuthenticationError,
+    DNSAPIError,
 )
 
-from ._utils import (
-    normalize_dns_name,
-)
+from ._utils import normalize_dns_name
 
 
 def create_module_argument_spec(provider_information):

--- a/plugins/module_utils/names.py
+++ b/plugins/module_utils/names.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 import re

--- a/plugins/module_utils/options.py
+++ b/plugins/module_utils/options.py
@@ -4,13 +4,13 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
-from ansible_collections.community.dns.plugins.module_utils.argspec import (
-    ArgumentSpec,
-)
+from ansible_collections.community.dns.plugins.module_utils.argspec import ArgumentSpec
 
 
 def create_bulk_operations_argspec(provider_information):

--- a/plugins/module_utils/provider.py
+++ b/plugins/module_utils/provider.py
@@ -4,21 +4,22 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import abc
 
 from ansible.module_utils import six
-
 from ansible.module_utils.common.validation import (
-    check_type_str,
-    check_type_list,
-    check_type_dict,
     check_type_bool,
-    check_type_int,
+    check_type_dict,
     check_type_float,
+    check_type_int,
+    check_type_list,
+    check_type_str,
 )
 
 

--- a/plugins/module_utils/record.py
+++ b/plugins/module_utils/record.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 import traceback
@@ -12,11 +14,12 @@ import traceback
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_native, to_text
 
+
 try:
     import dns
     import dns.exception
-    import dns.name
     import dns.message
+    import dns.name
     import dns.query
     import dns.rcode
     import dns.rdatatype

--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     DNSPYTHON_IMPORTERROR = traceback.format_exc()
 else:
-    DNSPYTHON_IMPORTERROR = None
+    DNSPYTHON_IMPORTERROR = None  # type: ignore  # TODO
 
 
 _EDNS_SIZE = 1232  # equals dns.message.DEFAULT_EDNS_PAYLOAD; larger values cause problems with Route53 nameservers for me

--- a/plugins/module_utils/wsdl.py
+++ b/plugins/module_utils/wsdl.py
@@ -4,12 +4,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import string_types
+
 
 try:
     import lxml.etree
@@ -17,9 +20,7 @@ try:
 except ImportError:
     HAS_LXML_ETREE = False
 
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    NetworkError,
-)
+from ansible_collections.community.dns.plugins.module_utils.http import NetworkError
 
 
 class WSDLException(Exception):

--- a/plugins/module_utils/zone.py
+++ b/plugins/module_utils/zone.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/module_utils/zone_record_api.py
+++ b/plugins/module_utils/zone_record_api.py
@@ -4,14 +4,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import abc
 
 from ansible.module_utils import six
-
 from ansible_collections.community.dns.plugins.module_utils.zone import (
     DNSZoneWithRecords,
 )

--- a/plugins/module_utils/zone_record_helpers.py
+++ b/plugins/module_utils/zone_record_helpers.py
@@ -4,7 +4,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -73,21 +75,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hetzner_dns_record_info.py
+++ b/plugins/modules/hetzner_dns_record_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -108,24 +110,18 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/hetzner_dns_record_set.py
+++ b/plugins/modules/hetzner_dns_record_set.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -189,21 +191,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_set import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hetzner_dns_record_set_info.py
+++ b/plugins/modules/hetzner_dns_record_set_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -169,24 +171,18 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_set_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/hetzner_dns_record_sets.py
+++ b/plugins/modules/hetzner_dns_record_sets.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -91,21 +93,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_sets import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hetzner_dns_zone_info.py
+++ b/plugins/modules/hetzner_dns_zone_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -167,24 +169,18 @@ zone_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    create_hetzner_argument_spec,
     create_hetzner_api,
+    create_hetzner_argument_spec,
     create_hetzner_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.zone_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/hosttech_dns_record.py
+++ b/plugins/modules/hosttech_dns_record.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -73,21 +75,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hosttech_dns_record_info.py
+++ b/plugins/modules/hosttech_dns_record_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -105,24 +107,18 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/hosttech_dns_record_set.py
+++ b/plugins/modules/hosttech_dns_record_set.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -196,21 +198,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_set import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hosttech_dns_record_set_info.py
+++ b/plugins/modules/hosttech_dns_record_set_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -168,24 +170,18 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_set_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/hosttech_dns_record_sets.py
+++ b/plugins/modules/hosttech_dns_record_sets.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -90,21 +92,15 @@ zone_id:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.record_sets import (
     create_module_argument_spec,
     run_module,

--- a/plugins/modules/hosttech_dns_zone_info.py
+++ b/plugins/modules/hosttech_dns_zone_info.py
@@ -5,7 +5,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -152,24 +154,18 @@ zone_info:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.argspec import (
     ModuleOptionProvider,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.http import (
-    ModuleHTTPHelper,
-)
-
 from ansible_collections.community.dns.plugins.module_utils.hosttech.api import (
-    create_hosttech_argument_spec,
     create_hosttech_api,
+    create_hosttech_argument_spec,
     create_hosttech_provider_information,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.http import ModuleHTTPHelper
 from ansible_collections.community.dns.plugins.module_utils.module.zone_info import (
-    run_module,
     create_module_argument_spec,
+    run_module,
 )
 
 

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -116,7 +118,6 @@ results:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolveDirectlyFromNameServers,
     assert_requirements_present,

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -465,16 +467,14 @@ results:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible_collections.community.dns.plugins.module_utils.dnspython_records import (
+    NAME_TO_RDTYPE,
+    convert_rdata_to_dict,
+)
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolveDirectlyFromNameServers,
     assert_requirements_present,
     guarded_run,
-)
-
-from ansible_collections.community.dns.plugins.module_utils.dnspython_records import (
-    NAME_TO_RDTYPE,
-    convert_rdata_to_dict,
 )
 
 

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
@@ -191,6 +193,7 @@ completed:
 
 import time
 
+
 try:
     from time import monotonic
 except ImportError:
@@ -198,12 +201,12 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text
-
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolveDirectlyFromNameServers,
     assert_requirements_present,
     guarded_run,
 )
+
 
 try:
     import dns.rdatatype

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -194,7 +194,7 @@ import time
 try:
     from time import monotonic
 except ImportError:
-    from time import clock as monotonic
+    from time import clock as monotonic  # type: ignore
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_text

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -12,29 +12,25 @@ import abc
 from ansible.errors import AnsibleError
 from ansible.module_utils.common._collections_compat import Sequence
 from ansible.plugins.inventory import BaseInventoryPlugin
-from ansible.utils.display import Display
 from ansible.template import Templar
-
-from ansible_collections.community.library_inventory_filtering_v1.plugins.plugin_utils.inventory_filter import parse_filters, filter_host
-
-from ansible_collections.community.dns.plugins.module_utils.provider import (
-    ensure_type,
-)
-
-from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
-    DNSAPIError,
-    DNSAPIAuthenticationError,
-)
-
+from ansible.utils.display import Display
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.provider import ensure_type
+from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
+    DNSAPIAuthenticationError,
+    DNSAPIError,
+)
 from ansible_collections.community.dns.plugins.plugin_utils.unsafe import make_unsafe
+from ansible_collections.community.library_inventory_filtering_v1.plugins.plugin_utils.inventory_filter import (
+    filter_host,
+    parse_filters,
+)
+
 
 display = Display()
 

--- a/plugins/plugin_utils/ips.py
+++ b/plugins/plugin_utils/ips.py
@@ -14,7 +14,7 @@ try:
 except ImportError as exc:  # pragma: no cover
     IPADDRESS_IMPORT_EXC = exc  # pragma: no cover
 else:
-    IPADDRESS_IMPORT_EXC = None
+    IPADDRESS_IMPORT_EXC = None  # type: ignore  # TODO
 
 
 def assert_requirements_present(plugin_name, plugin_type):

--- a/plugins/plugin_utils/ips.py
+++ b/plugins/plugin_utils/ips.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import missing_required_lib
 
+
 try:
     import ipaddress  # pylint: disable=unused-import
 except ImportError as exc:  # pragma: no cover

--- a/plugins/plugin_utils/public_suffix.py
+++ b/plugins/plugin_utils/public_suffix.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import os.path
 import re
 
-from ansible_collections.community.dns.plugins.module_utils.names import InvalidDomainName, split_into_labels, normalize_label
+from ansible_collections.community.dns.plugins.module_utils.names import (
+    InvalidDomainName,
+    normalize_label,
+    split_into_labels,
+)
 
 
 _BEGIN_SUBSET_MATCHER = re.compile(r'===BEGIN ([^=]*) DOMAINS===')

--- a/plugins/plugin_utils/resolver.py
+++ b/plugins/plugin_utils/resolver.py
@@ -9,16 +9,16 @@ from __future__ import annotations
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
-
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolverError,
 )
 
+
 try:
     import dns  # pylint: disable=unused-import
     import dns.exception  # pylint: disable=unused-import
-    import dns.name  # pylint: disable=unused-import
     import dns.message  # pylint: disable=unused-import
+    import dns.name  # pylint: disable=unused-import
     import dns.query  # pylint: disable=unused-import
     import dns.rcode  # pylint: disable=unused-import
     import dns.rdatatype  # pylint: disable=unused-import

--- a/plugins/plugin_utils/resolver.py
+++ b/plugins/plugin_utils/resolver.py
@@ -26,7 +26,7 @@ try:
 except ImportError as exc:
     DNSPYTHON_IMPORTERROR = exc
 else:
-    DNSPYTHON_IMPORTERROR = None
+    DNSPYTHON_IMPORTERROR = None  # type: ignore  # TODO
 
 
 def guarded_run(runner, error_class=AnsibleError, server=None):

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -8,10 +8,9 @@ import re
 
 from ansible.module_utils.common._collections_compat import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
-from ansible.utils.unsafe_proxy import (
-    AnsibleUnsafe,
-    wrap_var as _make_unsafe,
-)
+from ansible.utils.unsafe_proxy import AnsibleUnsafe
+from ansible.utils.unsafe_proxy import wrap_var as _make_unsafe
+
 
 _RE_TEMPLATE_CHARS = re.compile(u'[{}]')
 _RE_TEMPLATE_CHARS_BYTES = re.compile(b'[{}]')

--- a/tests/nox-config-black.toml
+++ b/tests/nox-config-black.toml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[tool.black]
+target-version = ['py35']

--- a/tests/nox-config-flake8.ini
+++ b/tests/nox-config-flake8.ini
@@ -1,0 +1,13 @@
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025 Felix Fontein <felix@fontein.de>
+
+[flake8]
+extend-ignore = E203, E402, F401
+count = true
+# TODO: decrease this to ~10
+max-complexity = 33
+# black's max-line-length is 89, but it doesn't touch long string literals.
+# Since ansible-test's limit is 160, let's use that here.
+max-line-length = 160
+statistics = true

--- a/tests/nox-config-isort.cfg
+++ b/tests/nox-config-isort.cfg
@@ -1,0 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[isort]
+profile=black
+lines_after_imports = 2

--- a/tests/nox-config-mypy.ini
+++ b/tests/nox-config-mypy.ini
@@ -1,0 +1,14 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[mypy]
+namespace_packages = True
+explicit_package_bases = True
+
+[mypy-ansible.*]
+# ansible-core has no typing information
+ignore_missing_imports = True
+
+[mypy-ansible_collections.community.internal_test_tools.tests.unit.compat.mock]
+ignore_errors = True

--- a/tests/nox-config-pylint-py2.rc
+++ b/tests/nox-config-pylint-py2.rc
@@ -1,0 +1,528 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=pydantic
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,.git
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=
+    duplicate-code,
+    fixme,
+    invalid-name,
+    locally-disabled,
+    missing-class-docstring,
+    missing-function-docstring,
+    missing-module-docstring,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-lines,
+    too-many-locals,
+    too-many-positional-arguments,
+    too-many-public-methods,
+    too-many-return-statements,
+    too-many-statements,
+    ungrouped-imports,
+    wrong-import-order,
+    wrong-import-position,
+    # Needed for Python 2:
+    consider-using-f-string,
+    raise-missing-from,
+    redundant-u-string-prefix,
+    useless-object-inheritance,
+    super-with-arguments,
+    # Fix:
+    inconsistent-return-statements,
+    no-self-use,
+    redefined-builtin,
+    # Maybe fix:
+    broad-exception-caught,
+    c-extension-no-member,
+    function-redefined,
+    protected-access,
+    unused-argument,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+#    c-extension-no-member,
+#    useless-suppression,
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention + info) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=ex,
+           _,
+           f,
+           e
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=160
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=new
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging,twiggy
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=

--- a/tests/nox-config-pylint.rc
+++ b/tests/nox-config-pylint.rc
@@ -1,0 +1,528 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=pydantic
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,.git
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=
+    duplicate-code,
+    fixme,
+    invalid-name,
+    locally-disabled,
+    missing-class-docstring,
+    missing-function-docstring,
+    missing-module-docstring,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-lines,
+    too-many-locals,
+    too-many-positional-arguments,
+    too-many-public-methods,
+    too-many-return-statements,
+    too-many-statements,
+    ungrouped-imports,
+    wrong-import-order,
+    wrong-import-position,
+    # Fix (Python 2):
+    consider-using-f-string,
+    raise-missing-from,
+    redundant-u-string-prefix,
+    useless-object-inheritance,
+    super-with-arguments,
+    # Fix:
+    inconsistent-return-statements,
+    no-self-use,
+    redefined-builtin,
+    # Maybe fix:
+    broad-exception-caught,
+    c-extension-no-member,
+    function-redefined,
+    protected-access,
+    unused-argument,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+#    c-extension-no-member,
+#    useless-suppression,
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention + info) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=ex,
+           _,
+           f,
+           e
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=160
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=new
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging,twiggy
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=

--- a/tests/nox-requirements-codeqa.txt
+++ b/tests/nox-requirements-codeqa.txt
@@ -1,0 +1,9 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+ansible-core  # used by various code
+flake8
+pylint
+pytest  # used by unit tests
+-r unit/requirements.txt

--- a/tests/nox-requirements-formatters.txt
+++ b/tests/nox-requirements-formatters.txt
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+black
+isort

--- a/tests/nox-requirements-typing.txt
+++ b/tests/nox-requirements-typing.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# ansible-core  # currently has no typing information
+mypy
+pytest  # used by unit tests
+types-lxml
+types-mock
+-r unit/requirements.txt

--- a/tests/unit/plugins/inventory/test_hetzner_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hetzner_dns_records.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-
 import os
 import textwrap
 
@@ -12,9 +11,12 @@ from ansible import constants as C
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.unsafe_proxy import AnsibleUnsafe
-
-from ansible_collections.community.internal_test_tools.tests.unit.mock.path import mock_unfrackpath_noop
-from ansible_collections.community.internal_test_tools.tests.unit.mock.loader import DictDataLoader
+from ansible_collections.community.internal_test_tools.tests.unit.mock.loader import (
+    DictDataLoader,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.mock.path import (
+    mock_unfrackpath_noop,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.open_url_framework import (
     OpenUrlCall,
     OpenUrlProxy,

--- a/tests/unit/plugins/inventory/test_hosttech_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hosttech_dns_records.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-
 import os
 import textwrap
 
@@ -12,9 +11,12 @@ from ansible import constants as C
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.unsafe_proxy import AnsibleUnsafe
-
-from ansible_collections.community.internal_test_tools.tests.unit.mock.path import mock_unfrackpath_noop
-from ansible_collections.community.internal_test_tools.tests.unit.mock.loader import DictDataLoader
+from ansible_collections.community.internal_test_tools.tests.unit.mock.loader import (
+    DictDataLoader,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.mock.path import (
+    mock_unfrackpath_noop,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.open_url_framework import (
     OpenUrlCall,
     OpenUrlProxy,

--- a/tests/unit/plugins/lookup/test_lookup.py
+++ b/tests/unit/plugins/lookup/test_lookup.py
@@ -5,20 +5,23 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.loader import lookup_loader
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import TestCase
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import (
+    TestCase,
+)
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/lookup/test_lookup_as_dict.py
+++ b/tests/unit/plugins/lookup/test_lookup_as_dict.py
@@ -5,20 +5,23 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.loader import lookup_loader
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import TestCase
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import (
+    TestCase,
+)
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/lookup/test_reverse_lookup.py
+++ b/tests/unit/plugins/lookup/test_reverse_lookup.py
@@ -5,20 +5,23 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.loader import lookup_loader
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import TestCase
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.compat.unittest import (
+    TestCase,
+)
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/module_utils/conversion/test_converter.py
+++ b/tests/unit/plugins/module_utils/conversion/test_converter.py
@@ -6,27 +6,20 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.converter import (
     RecordConverter,
 )
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
-from ..helper import (
-    CustomProviderInformation,
-    CustomProvideOptions,
-)
+from ..helper import CustomProvideOptions, CustomProviderInformation
 
 
 def test_user_api():

--- a/tests/unit/plugins/module_utils/conversion/test_txt.py
+++ b/tests/unit/plugins/module_utils/conversion/test_txt.py
@@ -6,17 +6,16 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import warnings
 
 import pytest
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.base import (
     DNSConversionError,
 )
-
 from ansible_collections.community.dns.plugins.module_utils.conversion.txt import (
     _get_utf8_length,
     decode_txt_value,

--- a/tests/unit/plugins/module_utils/helper.py
+++ b/tests/unit/plugins/module_utils/helper.py
@@ -6,6 +6,7 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 

--- a/tests/unit/plugins/module_utils/hetzner/test_api.py
+++ b/tests/unit/plugins/module_utils/hetzner/test_api.py
@@ -6,23 +6,20 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
+from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
+    HetznerAPI,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.hetzner.api import (
-    HetznerAPI,
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
 )
 
 

--- a/tests/unit/plugins/module_utils/hosttech/test_api.py
+++ b/tests/unit/plugins/module_utils/hosttech/test_api.py
@@ -6,22 +6,20 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
-
+from ansible_collections.community.dns.plugins.module_utils.hosttech import api
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.hosttech import api
-
-from ..helper import (
-    CustomProvideOptions,
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
 )
+
+from ..helper import CustomProvideOptions
 
 
 def test_internal_error():

--- a/tests/unit/plugins/module_utils/hosttech/test_json_api.py
+++ b/tests/unit/plugins/module_utils/hosttech/test_json_api.py
@@ -6,25 +6,22 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
-
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
+from ansible_collections.community.dns.plugins.module_utils.hosttech.json_api import (
+    HostTechJSONAPI,
+    _create_record_from_json,
+    _record_to_json,
 )
-
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.hosttech.json_api import (
-    _create_record_from_json,
-    _record_to_json,
-    HostTechJSONAPI,
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
 )
 
 

--- a/tests/unit/plugins/module_utils/module/test__utils.py
+++ b/tests/unit/plugins/module_utils/module/test__utils.py
@@ -6,23 +6,20 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
+from ansible_collections.community.dns.plugins.module_utils.module._utils import (
+    get_prefix,
+    normalize_dns_name,
+)
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )
 
-from ansible_collections.community.dns.plugins.module_utils.module._utils import (
-    normalize_dns_name,
-    get_prefix,
-)
-
-from ..helper import (
-    CustomProviderInformation,
-)
+from ..helper import CustomProviderInformation
 
 
 def test_normalize_dns_name():

--- a/tests/unit/plugins/module_utils/resolver_helper.py
+++ b/tests/unit/plugins/module_utils/resolver_helper.py
@@ -6,10 +6,14 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+)
+
 
 try:
     import dns.rcode

--- a/tests/unit/plugins/module_utils/test_argspec.py
+++ b/tests/unit/plugins/module_utils/test_argspec.py
@@ -6,12 +6,11 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
-from ansible_collections.community.dns.plugins.module_utils.argspec import (
-    ArgumentSpec,
-)
+from ansible_collections.community.dns.plugins.module_utils.argspec import ArgumentSpec
 
 
 def test_argspec():

--- a/tests/unit/plugins/module_utils/test_dnspython_records.py
+++ b/tests/unit/plugins/module_utils/test_dnspython_records.py
@@ -6,15 +6,16 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
 from ansible_collections.community.dns.plugins.module_utils.dnspython_records import (
     RDTYPE_TO_FIELDS,
     convert_rdata_to_dict,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/module_utils/test_http.py
+++ b/tests/unit/plugins/module_utils/test_http.py
@@ -6,18 +6,16 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible.module_utils.urls import NoSSLError, ConnectionError
-
+from ansible.module_utils.urls import ConnectionError, NoSSLError
 from ansible_collections.community.dns.plugins.module_utils.http import (
     NetworkError,
     OpenURLHelper,
 )
-
 from ansible_collections.community.internal_test_tools.tests.unit.utils.open_url_framework import (
     OpenUrlCall,
     OpenUrlProxy,

--- a/tests/unit/plugins/module_utils/test_ips.py
+++ b/tests/unit/plugins/module_utils/test_ips.py
@@ -6,17 +6,17 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
 from ansible_collections.community.dns.plugins.module_utils import ips
-
 from ansible_collections.community.dns.plugins.module_utils.ips import (
     assert_requirements_present,
     is_ip_address,
 )
+
 
 # We need ipaddress
 ipaddress = pytest.importorskip('ipaddress')

--- a/tests/unit/plugins/module_utils/test_json_api_helper.py
+++ b/tests/unit/plugins/module_utils/test_json_api_helper.py
@@ -6,20 +6,20 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
-
+from ansible_collections.community.dns.plugins.module_utils.json_api_helper import (
+    JSONAPIHelper,
+    _get_header_value,
+)
 from ansible_collections.community.dns.plugins.module_utils.zone_record_api import (
     DNSAPIError,
 )
-
-from ansible_collections.community.dns.plugins.module_utils.json_api_helper import (
-    _get_header_value,
-    JSONAPIHelper,
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
 )
 
 

--- a/tests/unit/plugins/module_utils/test_names.py
+++ b/tests/unit/plugins/module_utils/test_names.py
@@ -6,17 +6,17 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
 from ansible_collections.community.dns.plugins.module_utils.names import (
-    join_labels,
+    InvalidDomainName,
     is_ascii_label,
+    join_labels,
     normalize_label,
     split_into_labels,
-    InvalidDomainName,
 )
 
 

--- a/tests/unit/plugins/module_utils/test_provider.py
+++ b/tests/unit/plugins/module_utils/test_provider.py
@@ -6,14 +6,12 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.dns.plugins.module_utils.provider import (
-    ensure_type,
-)
+from ansible_collections.community.dns.plugins.module_utils.provider import ensure_type
 
 
 CHECK_TYPE_DATA = [

--- a/tests/unit/plugins/module_utils/test_record.py
+++ b/tests/unit/plugins/module_utils/test_record.py
@@ -6,13 +6,14 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 from ansible_collections.community.dns.plugins.module_utils.record import (
-    format_ttl,
     DNSRecord,
     format_records_for_output,
+    format_ttl,
 )
 
 

--- a/tests/unit/plugins/module_utils/test_resolver.py
+++ b/tests/unit/plugins/module_utils/test_resolver.py
@@ -6,27 +6,29 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
-
 from ansible_collections.community.dns.plugins.module_utils import resolver
-
 from ansible_collections.community.dns.plugins.module_utils.resolver import (
     ResolveDirectlyFromNameServers,
     ResolverError,
     assert_requirements_present,
 )
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
 
 from .resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
     create_mock_response,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/module_utils/test_wsdl.py
+++ b/tests/unit/plugins/module_utils/test_wsdl.py
@@ -4,23 +4,24 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 
 import sys
-import pytest
 
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
+import pytest
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+)
+
 
 lxmletree = pytest.importorskip("lxml.etree")
 
 from ansible.module_utils.common.text.converters import to_native
-
-from ansible_collections.community.dns.plugins.module_utils.wsdl import (
-    Parser,
-    Composer,
-)
+from ansible_collections.community.dns.plugins.module_utils.wsdl import Composer, Parser
 
 
 def test_composer_generation():

--- a/tests/unit/plugins/module_utils/test_zone.py
+++ b/tests/unit/plugins/module_utils/test_zone.py
@@ -6,13 +6,11 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
-from ansible_collections.community.dns.plugins.module_utils.record import (
-    DNSRecord,
-)
-
+from ansible_collections.community.dns.plugins.module_utils.record import DNSRecord
 from ansible_collections.community.dns.plugins.module_utils.zone import (
     DNSZone,
     DNSZoneWithRecords,

--- a/tests/unit/plugins/modules/hetzner.py
+++ b/tests/unit/plugins/modules/hetzner.py
@@ -3,7 +3,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 

--- a/tests/unit/plugins/modules/hosttech.py
+++ b/tests/unit/plugins/modules/hosttech.py
@@ -3,7 +3,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
 try:

--- a/tests/unit/plugins/modules/test_hetzner_dns_record.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record.py
@@ -3,18 +3,18 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import hetzner_dns_record
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_record
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_DEFAULT_ENTRIES,

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_info.py
@@ -3,20 +3,21 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
-
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_info
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_ZONE_GET_RESULT,

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set.py
@@ -3,18 +3,18 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_set
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_set
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_DEFAULT_ENTRIES,

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_set_info.py
@@ -3,20 +3,23 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
-
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import (
+    hetzner_dns_record_set_info,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_set_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_ZONE_GET_RESULT,

--- a/tests/unit/plugins/modules/test_hetzner_dns_record_sets.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record_sets.py
@@ -3,18 +3,18 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_sets
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_record_sets
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_ZONE_GET_RESULT,

--- a/tests/unit/plugins/modules/test_hetzner_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_zone_info.py
@@ -3,18 +3,18 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
+from ansible_collections.community.dns.plugins.modules import hetzner_dns_zone_info
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
-
-from ansible_collections.community.dns.plugins.modules import hetzner_dns_zone_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 
 from .hetzner import (
     HETZNER_JSON_ZONE_GET_RESULT,

--- a/tests/unit/plugins/modules/test_hosttech_dns_record.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record.py
@@ -3,37 +3,37 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
+from ansible_collections.community.dns.plugins.modules import hosttech_dns_record
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_record
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
-    expect_wsdl_authentication,
-    expect_wsdl_value,
-    validate_wsdl_call,
-    validate_wsdl_add_request,
-    validate_wsdl_del_request,
-    create_wsdl_add_result,
-    create_wsdl_del_result,
-    HOSTTECH_WSDL_DEFAULT_ENTRIES,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     HOSTTECH_JSON_DEFAULT_ENTRIES,
     HOSTTECH_JSON_ZONE_GET_RESULT,
     HOSTTECH_JSON_ZONE_LIST_RESULT,
     HOSTTECH_JSON_ZONE_RECORDS_GET_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ENTRIES,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
+    create_wsdl_add_result,
+    create_wsdl_del_result,
+    expect_wsdl_authentication,
+    expect_wsdl_value,
+    validate_wsdl_add_request,
+    validate_wsdl_call,
+    validate_wsdl_del_request,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_info.py
@@ -3,32 +3,33 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
-
+from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_info
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
+    HOSTTECH_JSON_ZONE_GET_RESULT,
+    HOSTTECH_JSON_ZONE_LIST_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     expect_wsdl_authentication,
     expect_wsdl_value,
     validate_wsdl_call,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
-    HOSTTECH_JSON_ZONE_GET_RESULT,
-    HOSTTECH_JSON_ZONE_LIST_RESULT,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_set.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_set.py
@@ -3,39 +3,39 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
+from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_set
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_set
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
-    expect_wsdl_authentication,
-    expect_wsdl_value,
-    validate_wsdl_call,
-    validate_wsdl_add_request,
-    validate_wsdl_update_request,
-    validate_wsdl_del_request,
-    create_wsdl_add_result,
-    create_wsdl_update_result,
-    create_wsdl_del_result,
-    HOSTTECH_WSDL_DEFAULT_ENTRIES,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     HOSTTECH_JSON_DEFAULT_ENTRIES,
     HOSTTECH_JSON_ZONE_GET_RESULT,
     HOSTTECH_JSON_ZONE_LIST_RESULT,
     HOSTTECH_JSON_ZONE_RECORDS_GET_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ENTRIES,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
+    create_wsdl_add_result,
+    create_wsdl_del_result,
+    create_wsdl_update_result,
+    expect_wsdl_authentication,
+    expect_wsdl_value,
+    validate_wsdl_add_request,
+    validate_wsdl_call,
+    validate_wsdl_del_request,
+    validate_wsdl_update_request,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_set_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_set_info.py
@@ -3,32 +3,35 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
-
+from ansible_collections.community.dns.plugins.modules import (
+    hosttech_dns_record_set_info,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_set_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
+    HOSTTECH_JSON_ZONE_GET_RESULT,
+    HOSTTECH_JSON_ZONE_LIST_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     expect_wsdl_authentication,
     expect_wsdl_value,
     validate_wsdl_call,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
-    HOSTTECH_JSON_ZONE_GET_RESULT,
-    HOSTTECH_JSON_ZONE_LIST_RESULT,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_hosttech_dns_record_sets.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record_sets.py
@@ -3,36 +3,36 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
+from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_sets
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_record_sets
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
-    expect_wsdl_authentication,
-    expect_wsdl_value,
-    validate_wsdl_call,
-    validate_wsdl_add_request,
-    validate_wsdl_update_request,
-    validate_wsdl_del_request,
-    create_wsdl_add_result,
-    create_wsdl_update_result,
-    create_wsdl_del_result,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     HOSTTECH_JSON_ZONE_GET_RESULT,
     HOSTTECH_JSON_ZONE_LIST_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
+    create_wsdl_add_result,
+    create_wsdl_del_result,
+    create_wsdl_update_result,
+    expect_wsdl_authentication,
+    expect_wsdl_value,
+    validate_wsdl_add_request,
+    validate_wsdl_call,
+    validate_wsdl_del_request,
+    validate_wsdl_update_request,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_zone_info.py
@@ -3,31 +3,31 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
+# These imports are needed so patching below works
+import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
 import pytest
-
+from ansible_collections.community.dns.plugins.modules import hosttech_dns_zone_info
 from ansible_collections.community.internal_test_tools.tests.unit.utils.fetch_url_module_framework import (
     BaseTestModule,
     FetchUrlCall,
 )
 
-from ansible_collections.community.dns.plugins.modules import hosttech_dns_zone_info
-
-# These imports are needed so patching below works
-import ansible_collections.community.dns.plugins.module_utils.http  # noqa: F401, pylint: disable=unused-import
-
 from .hosttech import (
+    HOSTTECH_JSON_ZONE_2_GET_RESULT,
+    HOSTTECH_JSON_ZONE_GET_RESULT,
+    HOSTTECH_JSON_ZONE_LIST_RESULT,
+    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
+    HOSTTECH_WSDL_ZONE_NOT_FOUND,
     expect_wsdl_authentication,
     expect_wsdl_value,
     validate_wsdl_call,
-    HOSTTECH_WSDL_DEFAULT_ZONE_RESULT,
-    HOSTTECH_WSDL_ZONE_NOT_FOUND,
-    HOSTTECH_JSON_ZONE_GET_RESULT,
-    HOSTTECH_JSON_ZONE_2_GET_RESULT,
-    HOSTTECH_JSON_ZONE_LIST_RESULT,
 )
+
 
 try:
     import lxml.etree

--- a/tests/unit/plugins/modules/test_nameserver_info.py
+++ b/tests/unit/plugins/modules/test_nameserver_info.py
@@ -6,28 +6,30 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
-
+from ansible_collections.community.dns.plugins.modules import nameserver_info
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
-    set_module_args,
-    ModuleTestCase,
     AnsibleExitJson,
     AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
 )
-
-from ansible_collections.community.dns.plugins.modules import nameserver_info
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
     create_mock_response,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/modules/test_nameserver_record_info.py
+++ b/tests/unit/plugins/modules/test_nameserver_record_info.py
@@ -6,28 +6,30 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
-
+from ansible_collections.community.dns.plugins.modules import nameserver_record_info
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
-    set_module_args,
-    ModuleTestCase,
     AnsibleExitJson,
     AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
 )
-
-from ansible_collections.community.dns.plugins.modules import nameserver_record_info
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
     create_mock_response,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/modules/test_wait_for_txt.py
+++ b/tests/unit/plugins/modules/test_wait_for_txt.py
@@ -6,28 +6,30 @@
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
+
 __metaclass__ = type
 
 
 import pytest
-
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
-
+from ansible_collections.community.dns.plugins.modules import wait_for_txt
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
+    MagicMock,
+    patch,
+)
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
-    set_module_args,
-    ModuleTestCase,
     AnsibleExitJson,
     AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
 )
-
-from ansible_collections.community.dns.plugins.modules import wait_for_txt
 
 from ..module_utils.resolver_helper import (
-    mock_resolver,
-    mock_query_udp,
     create_mock_answer,
     create_mock_response,
+    mock_query_udp,
+    mock_resolver,
 )
+
 
 # We need dnspython
 dns = pytest.importorskip('dns')

--- a/tests/unit/plugins/plugin_utils/test_ips.py
+++ b/tests/unit/plugins/plugin_utils/test_ips.py
@@ -5,16 +5,13 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible.errors import AnsibleError
-
 from ansible_collections.community.dns.plugins.plugin_utils import ips
-
 from ansible_collections.community.dns.plugins.plugin_utils.ips import (
     assert_requirements_present,
 )
+
 
 # We need ipaddress
 ipaddress = pytest.importorskip('ipaddress')

--- a/tests/unit/plugins/plugin_utils/test_public_suffix.py
+++ b/tests/unit/plugins/plugin_utils/test_public_suffix.py
@@ -9,12 +9,10 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible_collections.community.dns.plugins.plugin_utils.public_suffix import (
-    PublicSuffixList,
     PUBLIC_SUFFIX_LIST,
+    PublicSuffixList,
 )
 
 

--- a/tests/unit/plugins/plugin_utils/test_resolver.py
+++ b/tests/unit/plugins/plugin_utils/test_resolver.py
@@ -5,13 +5,9 @@
 
 from __future__ import annotations
 
-
 import pytest
-
 from ansible.errors import AnsibleError
-
 from ansible_collections.community.dns.plugins.plugin_utils import resolver
-
 from ansible_collections.community.dns.plugins.plugin_utils.resolver import (
     assert_requirements_present,
 )

--- a/tests/unit/plugins/plugin_utils/test_unsafe.py
+++ b/tests/unit/plugins/plugin_utils/test_unsafe.py
@@ -5,17 +5,10 @@
 
 from __future__ import annotations
 
-
 import pytest
-
-from ansible.utils.unsafe_proxy import (
-    AnsibleUnsafe,
-    wrap_var as ansible_make_unsafe,
-)
-
-from ansible_collections.community.dns.plugins.plugin_utils.unsafe import (
-    make_unsafe,
-)
+from ansible.utils.unsafe_proxy import AnsibleUnsafe
+from ansible.utils.unsafe_proxy import wrap_var as ansible_make_unsafe
+from ansible_collections.community.dns.plugins.plugin_utils.unsafe import make_unsafe
 
 
 TEST_MAKE_UNSAFE = [


### PR DESCRIPTION
##### SUMMARY
Follow-up experiment to #231.

Unfortunately I wasn't able to use black to reformat the code since black destroys Python 2.7 code, and the last version to not do that is a beta version that apparently no longer works on Python 3.13. So this has to wait until we drop support for Python 2.7...

##### ISSUE TYPE
- Test Pull Request
- Feature Pull Request

##### COMPONENT NAME
collecftion
