### PR TITLE
lookup plugins: remove type=ALL which never worked

### DIFF
--- a/changelogs/fragments/265-lookup-all.yml
+++ b/changelogs/fragments/265-lookup-all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "lookup and lookup_as_dict lookup plugins - removed type ``ALL``, which never worked (https://github.com/ansible-collections/community.dns/issues/264, https://github.com/ansible-collections/community.dns/pull/265)."

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -31,7 +31,6 @@ options:
     default: A
     choices:
       - A
-      - ALL
       - AAAA
       - CAA
       - CNAME

--- a/plugins/lookup/lookup_as_dict.py
+++ b/plugins/lookup/lookup_as_dict.py
@@ -31,7 +31,6 @@ options:
     default: A
     choices:
       - A
-      - ALL
       - AAAA
       - CAA
       - CNAME


### PR DESCRIPTION
##### SUMMARY
Fixes #264.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup
lookup_as_dict
