### PR TITLE
Add Hetzner DNS A record using prefix parameter

### DIFF
--- a/plugins/modules/hetzner_dns_record.py
+++ b/plugins/modules/hetzner_dns_record.py
@@ -55,6 +55,15 @@ EXAMPLES = r"""
     value: 1.1.1.1
     hetzner_token: access_token
 
+- name: Add A record using prefix for www.example.com
+  community.dns.hetzner_dns_record:
+    state: present
+    zone_name: example.com
+    prefix: www
+    type: A
+    value: 198.51.100.25
+    hetzner_token: "{{ lookup('env', 'HETZNER_DNS_TOKEN') }}"
+
 - name: Remove a new.foo.com A record
   community.dns.hetzner_dns_record:
     state: absent


### PR DESCRIPTION
##### SUMMARY
- Adding an A record for `www.example.com` using the `prefix` parameter with the `community.dns.hetzner_dns_record` module.



##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
community.dns.hetzner_dns_record

