### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/280-deprecations.yml
+++ b/changelogs/fragments/280-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.dns/pull/280)."

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -11,7 +11,7 @@ import abc
 import typing as t
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.common._collections_compat import Sequence
+from collections.abc import Sequence
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.template import Templar
 from ansible.utils.display import Display

--- a/plugins/plugin_utils/inventory/records.py
+++ b/plugins/plugin_utils/inventory/records.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import abc
 import typing as t
+from collections.abc import Sequence
 
 from ansible.errors import AnsibleError
-from collections.abc import Sequence
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.template import Templar
 from ansible.utils.display import Display

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import re
 import typing as t
-
 from collections.abc import Mapping, Set
+
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import AnsibleUnsafe
 from ansible.utils.unsafe_proxy import wrap_var as _make_unsafe

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 import typing as t
 
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import AnsibleUnsafe
 from ansible.utils.unsafe_proxy import wrap_var as _make_unsafe


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
