### PR TITLE
Typing: avoid deprecated typing.Callable

### DIFF
--- a/plugins/filter/domain_suffix.py
+++ b/plugins/filter/domain_suffix.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_text
@@ -144,7 +145,7 @@ def remove_public_suffix(
 class FilterModule:
     """Ansible jinja2 filters"""
 
-    def filters(self) -> dict[str, t.Callable]:
+    def filters(self) -> dict[str, Callable]:
         return {
             "get_public_suffix": get_public_suffix,
             "get_registrable_domain": get_registrable_domain,

--- a/plugins/filter/reverse_pointer.py
+++ b/plugins/filter/reverse_pointer.py
@@ -47,6 +47,7 @@ _value:
 
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_text
@@ -83,7 +84,7 @@ def reverse_pointer(ip: t.Any) -> str:
 class FilterModule:
     """Ansible jinja2 filters"""
 
-    def filters(self) -> dict[str, t.Callable]:
+    def filters(self) -> dict[str, Callable]:
         return {
             "reverse_pointer": reverse_pointer,
         }

--- a/plugins/filter/txt.py
+++ b/plugins/filter/txt.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_text
@@ -49,7 +50,7 @@ def unquote_txt(value: t.Any, character_encoding: t.Any = "decimal") -> str:
 class FilterModule:
     """Ansible jinja2 filters"""
 
-    def filters(self) -> dict[str, t.Callable]:
+    def filters(self) -> dict[str, Callable]:
         return {
             "quote_txt": quote_txt,
             "unquote_txt": unquote_txt,

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -127,6 +127,7 @@ _result:
 """
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_text
@@ -196,9 +197,7 @@ class LookupModule(LookupBase):
         )
 
     @staticmethod
-    def _get_resolver(
-        resolver: SimpleResolver, server: str
-    ) -> t.Callable[[], list[str]]:
+    def _get_resolver(resolver: SimpleResolver, server: str) -> Callable[[], list[str]]:
         def f():
             try:
                 return resolver.resolve_addresses(server)

--- a/plugins/lookup/lookup_as_dict.py
+++ b/plugins/lookup/lookup_as_dict.py
@@ -416,6 +416,7 @@ _result:
 """
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_text
@@ -484,9 +485,7 @@ class LookupModule(LookupBase):
         )
 
     @staticmethod
-    def _get_resolver(
-        resolver: SimpleResolver, server: str
-    ) -> t.Callable[[], list[str]]:
+    def _get_resolver(resolver: SimpleResolver, server: str) -> Callable[[], list[str]]:
         def f():
             try:
                 return resolver.resolve_addresses(server)

--- a/plugins/lookup/reverse_lookup.py
+++ b/plugins/lookup/reverse_lookup.py
@@ -73,6 +73,7 @@ _result:
 """
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_text
@@ -137,9 +138,7 @@ class LookupModule(LookupBase):
         )
 
     @staticmethod
-    def _get_resolver(
-        resolver: SimpleResolver, server: str
-    ) -> t.Callable[[], list[str]]:
+    def _get_resolver(resolver: SimpleResolver, server: str) -> Callable[[], list[str]]:
         def f():
             try:
                 return resolver.resolve_addresses(server)

--- a/plugins/plugin_utils/resolver.py
+++ b/plugins/plugin_utils/resolver.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import typing as t
+from collections.abc import Callable
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import missing_required_lib
@@ -36,7 +37,7 @@ _T = t.TypeVar("_T")
 
 
 def guarded_run(
-    runner: t.Callable[[], _T],
+    runner: Callable[[], _T],
     error_class: t.Type[Exception] = AnsibleError,
     server: str | None = None,
 ) -> _T:

--- a/tests/unit/plugins/inventory/test_hetzner_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hetzner_dns_records.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import textwrap
 import typing as t
+from collections.abc import Callable
 
 from ansible import constants as C
 from ansible.inventory.manager import InventoryManager
@@ -216,7 +217,7 @@ original_access = os.access
 
 def exists_mock(
     path: os.PathLike | str, exists: bool = True
-) -> t.Callable[[os.PathLike | str], bool]:
+) -> Callable[[os.PathLike | str], bool]:
     def exists_fn(f: os.PathLike | str) -> bool:
         if to_native(f) == path:
             return exists

--- a/tests/unit/plugins/inventory/test_hosttech_dns_records.py
+++ b/tests/unit/plugins/inventory/test_hosttech_dns_records.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import textwrap
 import typing as t
+from collections.abc import Callable
 
 from ansible import constants as C
 from ansible.inventory.manager import InventoryManager
@@ -200,7 +201,7 @@ original_access = os.access
 
 def exists_mock(
     path: os.PathLike | str, can_access: bool = True
-) -> t.Callable[[os.PathLike | str], bool]:
+) -> Callable[[os.PathLike | str], bool]:
     def exists_fn(f: os.PathLike | str) -> bool:
         if to_native(f) == path:
             return can_access

--- a/tests/unit/plugins/plugin_utils/test_unsafe.py
+++ b/tests/unit/plugins/plugin_utils/test_unsafe.py
@@ -127,7 +127,7 @@ def test_make_unsafe_idempotence() -> None:
 
 
 def test_make_unsafe_dict_key() -> None:
-    value = {
+    value: dict[t.Any, t.Any] = {
         _make_trusted("test"): 2,
     }
     if not SUPPORTS_DATA_TAGGING:
@@ -149,7 +149,7 @@ def test_make_unsafe_dict_key() -> None:
 
 
 def test_make_unsafe_set() -> None:
-    value = set([_make_trusted("test")])
+    value: set[t.Any] = set([_make_trusted("test")])
     if not SUPPORTS_DATA_TAGGING:
         value.add(_make_trusted(b"test"))
     unsafe_value = make_unsafe(value)


### PR DESCRIPTION
##### SUMMARY
`typing.Callable` is deprecated; use `collections.abc.Callable` instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
