### PR TITLE
Remove support for dnspython < 2.0.0

### DIFF
--- a/changelogs/fragments/323-dnspython.yml
+++ b/changelogs/fragments/323-dnspython.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - "Drop support for dnspython < 2.0.0.
+     All modules and plugins that require dnspython will no longer work with older versions
+     (https://github.com/ansible-collections/community.dns/pull/323)."

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -10,7 +10,7 @@ author: Felix Fontein (@felixfontein)
 short_description: Look up DNS records
 version_added: 2.6.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 description:
   - Look up DNS records.
 options:

--- a/plugins/lookup/lookup_as_dict.py
+++ b/plugins/lookup/lookup_as_dict.py
@@ -10,7 +10,7 @@ author: Felix Fontein (@felixfontein)
 short_description: Look up DNS records as dictionaries
 version_added: 2.6.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 description:
   - Look up DNS records and return them as interpreted dictionaries.
 options:

--- a/plugins/lookup/lookup_rfc8427.py
+++ b/plugins/lookup/lookup_rfc8427.py
@@ -12,7 +12,7 @@ author:
 short_description: Look up DNS records and return RFC 8427 JSON format
 version_added: 3.4.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 description:
   - Look up DNS records and return them in L(RFC 8427 DNS message JSON format, https://www.rfc-editor.org/rfc/rfc8427.html).
   - RFC 8427 defines a standardized format for representing DNS messages in JSON.

--- a/plugins/lookup/reverse_lookup.py
+++ b/plugins/lookup/reverse_lookup.py
@@ -10,7 +10,7 @@ author: Felix Fontein (@felixfontein)
 short_description: Reverse-look up IP addresses
 version_added: 3.1.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 description:
   - Look up hostnames for IP addresses using DNS reverse lookup.
 options:

--- a/plugins/module_utils/_dnspython_records.py
+++ b/plugins/module_utils/_dnspython_records.py
@@ -205,19 +205,7 @@ def convert_rdata_to_dict(
         if rdata.rdtype == dns.rdatatype.NSEC3 and f == "next":
             val = to_native(base64.b32encode(rdata.next).translate(dns.rdtypes.ANY.NSEC3.b32_normal_to_hex).lower())  # type: ignore
         if rdata.rdtype in (dns.rdatatype.NSEC, dns.rdatatype.NSEC3) and f == "windows":
-            try:
-                val = dns.rdtypes.util.Bitmap(rdata.windows).to_text().lstrip(" ")  # type: ignore
-            except AttributeError:
-                # dnspython < 2.0.0
-                val = []
-                for window, bitmap in rdata.windows:  # type: ignore
-                    for i, byte in enumerate(bitmap):
-                        for j in range(8):
-                            if (byte >> (7 - j)) & 1 != 0:
-                                val.append(
-                                    dns.rdatatype.to_text(window * 256 + i * 8 + j)
-                                )
-                val = " ".join(val).lstrip(" ")
+            val = dns.rdtypes.util.Bitmap(rdata.windows).to_text().lstrip(" ")  # type: ignore
         if (
             rdata.rdtype in (dns.rdatatype.NSEC3, dns.rdatatype.NSEC3PARAM)
             and f == "salt"

--- a/plugins/module_utils/_resolver.py
+++ b/plugins/module_utils/_resolver.py
@@ -23,6 +23,7 @@ try:
     import dns.rcode
     import dns.rdatatype
     import dns.resolver
+    import dns.version
 except ImportError:
     DNSPYTHON_IMPORTERROR = traceback.format_exc()
 else:
@@ -110,25 +111,13 @@ class _Resolve:
     ) -> dns.rrset.RRset | None:
         retry = 0
         while True:
-            try:
-                response = self._handle_timeout(
-                    resolver.resolve,
-                    dnsname,
-                    lifetime=self.timeout,
-                    rdtype=rdtype,
-                    **kwargs,
-                )
-            except AttributeError:
-                # For dnspython < 2.0.0
-                resolver.search = kwargs.pop("search", False)  # type: ignore
-                try:
-                    response = self._handle_timeout(
-                        resolver.query, dnsname, lifetime=self.timeout, rdtype=rdtype, **kwargs  # type: ignore
-                    )
-                except TypeError:
-                    # For dnspython < 1.6.0
-                    resolver.lifetime = self.timeout
-                    response = self._handle_timeout(resolver.query, dnsname, rdtype=rdtype**kwargs)  # type: ignore
+            response = self._handle_timeout(
+                resolver.resolve,
+                dnsname,
+                lifetime=self.timeout,
+                rdtype=rdtype,
+                **kwargs,
+            )
             if (
                 response.response.rcode() == dns.rcode.SERVFAIL
                 and retry < self.servfail_retries
@@ -502,6 +491,12 @@ def guarded_run(
 def assert_requirements_present(module: AnsibleModule) -> None:
     if DNSPYTHON_IMPORTERROR is not None:
         module.fail_json(
-            msg=missing_required_lib("dnspython"),
+            msg=missing_required_lib("dnspython >= 2.0.0"),
+            exception=DNSPYTHON_IMPORTERROR,
+        )
+    if dns.version.MAJOR < 2:
+        module.fail_json(
+            msg=missing_required_lib("dnspython >= 2.0.0")
+            + f" Found version {dns.version.version}.",
             exception=DNSPYTHON_IMPORTERROR,
         )

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -60,7 +60,7 @@ options:
     elements: str
     version_added: 2.7.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nameserver_record_info.py
+++ b/plugins/modules/nameserver_record_info.py
@@ -89,11 +89,7 @@ options:
     elements: str
     version_added: 2.7.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
-notes:
-  - Dnspython before 2.0.0 does not correctly support (un-)escaping UTF-8 in TXT-like records. This can result in wrongly
-    decoded TXT records. Please use dnspython 2.0.0 or later to fix this issue; see also U(https://github.com/rthalley/dnspython/issues/321).
-    Unfortunately dnspython 2.0.0 requires Python 3.6 or newer.
+  - dnspython >= 2.0.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/wait_for_txt.py
+++ b/plugins/modules/wait_for_txt.py
@@ -111,7 +111,7 @@ options:
     elements: str
     version_added: 2.7.0
 requirements:
-  - dnspython >= 1.15.0 (maybe older versions also work)
+  - dnspython >= 2.0.0
 """
 
 EXAMPLES = r"""

--- a/plugins/plugin_utils/_resolver.py
+++ b/plugins/plugin_utils/_resolver.py
@@ -28,6 +28,7 @@ try:
     import dns.rcode  # pylint: disable=unused-import
     import dns.rdatatype  # pylint: disable=unused-import
     import dns.resolver  # pylint: disable=unused-import
+    import dns.version
 except ImportError as exc:
     DNSPYTHON_IMPORTERROR = exc
 else:
@@ -53,5 +54,11 @@ def guarded_run(
 
 def assert_requirements_present(plugin_name: str, plugin_type: str) -> None:
     if DNSPYTHON_IMPORTERROR is not None:
-        msg = f'The {plugin_name} {plugin_type} plugin is missing requirements: {missing_required_lib("dnspython")}'
+        msg = f'The {plugin_name} {plugin_type} plugin is missing requirements: {missing_required_lib("dnspython >= 2.0.0")}'
         raise AnsibleError(msg) from DNSPYTHON_IMPORTERROR
+    if dns.version.MAJOR < 2:
+        msg = (
+            f'The {plugin_name} {plugin_type} plugin is missing requirements: {missing_required_lib("dnspython >= 2.0.0")}.'
+            f" Found version {dns.version.version}."
+        )
+        raise AnsibleError(msg)

--- a/tests/unit/plugins/module_utils/test__dnspython_records.py
+++ b/tests/unit/plugins/module_utils/test__dnspython_records.py
@@ -14,8 +14,6 @@ from ansible_collections.community.dns.plugins.module_utils._dnspython_records i
 # We need dnspython
 dns = pytest.importorskip("dns")
 
-import dns.version  # noqa: F811
-
 TEST_CONVERT_RDATA_TO_DICT = [
     (
         dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.A, "3.3.3.3"),
@@ -355,54 +353,45 @@ TEST_CONVERT_RDATA_TO_DICT = [
             "value": "asdffoo bar",
         },
     ),
+    (
+        dns.rdata.from_text(
+            dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
+        ),
+        {"to_unicode": False, "add_synthetic": False},
+        {
+            "strings": [b"asdf", b"foo \xc3\xa4"],
+        },
+    ),
+    (
+        dns.rdata.from_text(
+            dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
+        ),
+        {"to_unicode": False, "add_synthetic": True},
+        {
+            "strings": [b"asdf", b"foo \xc3\xa4"],
+            "value": b"asdffoo \xc3\xa4",
+        },
+    ),
+    (
+        dns.rdata.from_text(
+            dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
+        ),
+        {"to_unicode": True, "add_synthetic": False},
+        {
+            "strings": ["asdf", "foo ä"],
+        },
+    ),
+    (
+        dns.rdata.from_text(
+            dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
+        ),
+        {"to_unicode": True, "add_synthetic": True},
+        {
+            "strings": ["asdf", "foo ä"],
+            "value": "asdffoo ä",
+        },
+    ),
 ]
-
-
-if dns.version.MAJOR >= 2:
-    # https://github.com/rthalley/dnspython/issues/321 makes this not working on dnspython < 2.0.0,
-    # which affects Python 3.5 and 2.x since these are only supported by dnspython < 2.0.0.
-    TEST_CONVERT_RDATA_TO_DICT.extend(
-        [
-            (
-                dns.rdata.from_text(
-                    dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
-                ),
-                {"to_unicode": False, "add_synthetic": False},
-                {
-                    "strings": [b"asdf", b"foo \xc3\xa4"],
-                },
-            ),
-            (
-                dns.rdata.from_text(
-                    dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
-                ),
-                {"to_unicode": False, "add_synthetic": True},
-                {
-                    "strings": [b"asdf", b"foo \xc3\xa4"],
-                    "value": b"asdffoo \xc3\xa4",
-                },
-            ),
-            (
-                dns.rdata.from_text(
-                    dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
-                ),
-                {"to_unicode": True, "add_synthetic": False},
-                {
-                    "strings": ["asdf", "foo ä"],
-                },
-            ),
-            (
-                dns.rdata.from_text(
-                    dns.rdataclass.IN, dns.rdatatype.TXT, r'asdf "foo \195\164"'
-                ),
-                {"to_unicode": True, "add_synthetic": True},
-                {
-                    "strings": ["asdf", "foo ä"],
-                    "value": "asdffoo ä",
-                },
-            ),
-        ]
-    )
 
 
 @pytest.mark.parametrize("rdata, kwarg, expected_result", TEST_CONVERT_RDATA_TO_DICT)


### PR DESCRIPTION
##### SUMMARY
dnspython 2.0.0 was released in July 2020. There's no reason to support versions before it any longer.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various
