### PR TITLE
Fix typing issues

### DIFF
--- a/plugins/module_utils/_wsdl.py
+++ b/plugins/module_utils/_wsdl.py
@@ -224,6 +224,7 @@ class Parser:
         self, result: dict[str, t.Any], node: lxml.etree.Element, where: str
     ) -> None:
         for child in node:
+            assert isinstance(child.tag, (str, bytes, lxml.etree.QName))
             tag = lxml.etree.QName(child.tag)
             if tag.namespace != self._api:
                 raise WSDLCodingException(

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -6,6 +6,7 @@ plugins/module_utils/_module/record_sets.py no-assert  # The asserts are mainly 
 plugins/module_utils/_module/_utils.py pep8:E704
 plugins/module_utils/_record.py pep8:E704
 plugins/module_utils/_record_set.py pep8:E704
+plugins/module_utils/_wsdl.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_zone.py pep8:E704
 plugins/module_utils/_zone_record_api.py pep8:E704
 plugins/module_utils/_zone_record_set_api.py pep8:E704

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,3 +1,4 @@
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_sets.py no-assert  # The asserts are mainly needed for type inference
+plugins/module_utils/_wsdl.py no-assert  # The asserts are mainly needed for type inference
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,3 +1,4 @@
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_sets.py no-assert  # The asserts are mainly needed for type inference
+plugins/module_utils/_wsdl.py no-assert  # The asserts are mainly needed for type inference
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -3,4 +3,5 @@ plugins/modules/nameserver_record_info.py validate-modules:bad-return-value-key 
 plugins/modules/wait_for_txt.py validate-modules:bad-return-value-key  # Bad return value 'values' is in the process of being renamed
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_sets.py no-assert  # The asserts are mainly needed for type inference
+plugins/module_utils/_wsdl.py no-assert  # The asserts are mainly needed for type inference
 plugins/public_suffix_list.dat no-smart-quotes

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -3,4 +3,5 @@ plugins/modules/nameserver_record_info.py validate-modules:bad-return-value-key 
 plugins/modules/wait_for_txt.py validate-modules:bad-return-value-key  # Bad return value 'values' is in the process of being renamed
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_sets.py no-assert  # The asserts are mainly needed for type inference
+plugins/module_utils/_wsdl.py no-assert  # The asserts are mainly needed for type inference
 plugins/public_suffix_list.dat no-smart-quotes


### PR DESCRIPTION
##### SUMMARY
```
Argument 1 to "QName" has incompatible type "str | bytes | bytearray | QName"; expected "str | bytes | QName | _Element"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
WSDL module utils
