### PR TITLE
CI: Use ansible-core 2.20 and 2.18 instead of 2.15 and 2.14 for EE tests

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -119,19 +119,23 @@ config.dependencies.python_interpreter.python_path = "/usr/bin/python3.14"
 runtime_environment = {"ANSIBLE_PRIVATE_ROLE_VARS" = "true"}
 
 [[sessions.ee_check.execution_environments]]
-name = "2.15-rocky-9"
-description = "ansible-core 2.15 @ Rocky Linux 9"
+name = "2.20-rocky-9"
+description = "ansible-core 2.20 @ Rocky Linux 9"
 test_playbooks = ["tests/ee/all.yml"]
 config.images.base_image.name = "quay.io/rockylinux/rockylinux:9"
-config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/stable-2.15.tar.gz"
+config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/stable-2.20.tar.gz"
 config.dependencies.ansible_runner.package_pip = "ansible-runner"
+config.dependencies.python_interpreter.package_system = "python3.12 python3.12-pip python3.12-wheel python3.12-cryptography"
+config.dependencies.python_interpreter.python_path = "/usr/bin/python3.12"
 runtime_environment = {"ANSIBLE_PRIVATE_ROLE_VARS" = "true"}
 
 [[sessions.ee_check.execution_environments]]
-name = "2.14-centos-stream-9"
-description = "ansible-core 2.14 @ CentOS Stream 9"
+name = "2.18-centos-stream-9"
+description = "ansible-core 2.18 @ CentOS Stream 9"
 test_playbooks = ["tests/ee/all.yml"]
 config.images.base_image.name = "quay.io/centos/centos:stream9"
-config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/stable-2.14.tar.gz"
+config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/stable-2.18.tar.gz"
 config.dependencies.ansible_runner.package_pip = "ansible-runner"
+config.dependencies.python_interpreter.package_system = "python3.11 python3.11-pip python3.11-wheel python3.11-cryptography"
+config.dependencies.python_interpreter.python_path = "/usr/bin/python3.11"
 runtime_environment = {"ANSIBLE_PRIVATE_ROLE_VARS" = "true"}


### PR DESCRIPTION
##### SUMMARY
The collection no longer supports ansible-core < 2.18.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
