### PR TITLE
Make sure to convert IDN prefix to punycode if zone_id is used

### DIFF
--- a/changelogs/fragments/340-prefix-normalize.yml
+++ b/changelogs/fragments/340-prefix-normalize.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "various DNS modules - if ``zone_id`` was combined with an IDN ``prefix``, the prefix was not converted to punycode
+     (https://github.com/ansible-collections/community.dns/pull/340)."

--- a/plugins/module_utils/_module/record.py
+++ b/plugins/module_utils/_module/record.py
@@ -120,7 +120,7 @@ def _run_module_record_api(
             module.params.get("zone_id"),
             record_type=type_in,
             prefix=(
-                provider_information.normalize_prefix(prefix_in)
+                provider_information.normalize_prefix(normalize_dns_name(prefix_in))
                 if prefix_in is not None
                 else NOT_PROVIDED
             ),
@@ -138,7 +138,7 @@ def _run_module_record_api(
         records = zone.records
     else:
         zone_id = module.params.get("zone_id")
-        prefix = provider_information.normalize_prefix(prefix_in)
+        prefix = provider_information.normalize_prefix(normalize_dns_name(prefix_in))
         records = api.get_zone_records(
             zone_id,
             record_type=type_in,
@@ -261,7 +261,7 @@ def _run_module_record_set_api(
             module.params.get("zone_id"),
             record_type=type_in,
             prefix=(
-                provider_information.normalize_prefix(prefix_in)
+                provider_information.normalize_prefix(normalize_dns_name(prefix_in))
                 if prefix_in is not None
                 else NOT_PROVIDED
             ),
@@ -279,7 +279,7 @@ def _run_module_record_set_api(
         record_sets = zone.record_sets
     else:
         zone_id = module.params.get("zone_id")
-        prefix = provider_information.normalize_prefix(prefix_in)
+        prefix = provider_information.normalize_prefix(normalize_dns_name(prefix_in))
         record_sets = api.get_zone_record_sets(
             zone_id,
             record_type=type_in,

--- a/plugins/module_utils/_module/record_info.py
+++ b/plugins/module_utils/_module/record_info.py
@@ -247,12 +247,12 @@ def run_module(
             module.fail_json(msg=f"Invalid record type {filter_record_type}")
         if module.params.get("prefix") is not None:
             filter_prefix = provider_information.normalize_prefix(
-                module.params.get("prefix")
+                normalize_dns_name(module.params.get("prefix"))
             )
     elif module.params.get("what") == "all_types_for_record":
         if module.params.get("prefix") is not None:
             filter_prefix = provider_information.normalize_prefix(
-                module.params.get("prefix")
+                normalize_dns_name(module.params.get("prefix"))
             )
 
     try:

--- a/plugins/module_utils/_module/record_set.py
+++ b/plugins/module_utils/_module/record_set.py
@@ -141,7 +141,7 @@ def _run_module_record_api(
             module.params.get("zone_id"),
             record_type=type_in,
             prefix=(
-                provider_information.normalize_prefix(prefix_in)
+                provider_information.normalize_prefix(normalize_dns_name(prefix_in))
                 if prefix_in is not None
                 else NOT_PROVIDED
             ),
@@ -159,7 +159,7 @@ def _run_module_record_api(
         records = zone.records
     else:
         zone_id = module.params.get("zone_id")
-        prefix = provider_information.normalize_prefix(prefix_in)
+        prefix = provider_information.normalize_prefix(normalize_dns_name(prefix_in))
         records = api.get_zone_records(
             zone_id,
             record_type=type_in,
@@ -358,7 +358,7 @@ def _run_module_record_set_api(
             module.params.get("zone_id"),
             record_type=type_in,
             prefix=(
-                provider_information.normalize_prefix(prefix_in)
+                provider_information.normalize_prefix(normalize_dns_name(prefix_in))
                 if prefix_in is not None
                 else NOT_PROVIDED
             ),
@@ -376,7 +376,7 @@ def _run_module_record_set_api(
         record_sets = zone.record_sets
     else:
         zone_id = module.params.get("zone_id")
-        prefix = provider_information.normalize_prefix(prefix_in)
+        prefix = provider_information.normalize_prefix(normalize_dns_name(prefix_in))
         record_sets = api.get_zone_record_sets(
             zone_id,
             record_type=type_in,

--- a/plugins/module_utils/_module/record_set_info.py
+++ b/plugins/module_utils/_module/record_set_info.py
@@ -328,12 +328,12 @@ def run_module(
             module.fail_json(msg=f"Invalid record type {filter_record_type}")
         if module.params.get("prefix") is not None:
             filter_prefix = provider_information.normalize_prefix(
-                module.params.get("prefix")
+                normalize_dns_name(module.params.get("prefix"))
             )
     elif module.params.get("what") == "all_types_for_record":
         if module.params.get("prefix") is not None:
             filter_prefix = provider_information.normalize_prefix(
-                module.params.get("prefix")
+                normalize_dns_name(module.params.get("prefix"))
             )
 
     try:

--- a/tests/unit/plugins/modules/test_hetzner_dns_record.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record.py
@@ -828,6 +828,62 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
         assert result["changed"] is True
         assert result["zone_id"] == "42"
 
+    def test_change_add_one_idn_prefix_zone_id(self, mocker):
+        result = self.run_module_success(
+            mocker,
+            hetzner_dns_record,
+            {
+                "hetzner_token": "foo",
+                "state": "present",
+                "zone_id": "42",
+                "prefix": "☺",
+                "type": "CAA",
+                "ttl": 3600,
+                "value": '128 issue "letsencrypt.org"',
+                "_ansible_remote_tmp": "/tmp/tmp",
+                "_ansible_keep_remote_files": True,
+            },
+            [
+                FetchUrlCall("GET", 200)
+                .expect_header("accept", "application/json")
+                .expect_header("auth-api-token", "foo")
+                .expect_url(
+                    "https://dns.hetzner.com/api/v1/records", without_query=True
+                )
+                .expect_query_values("zone_id", "42")
+                .expect_query_values("page", "1")
+                .expect_query_values("per_page", "100")
+                .return_header("Content-Type", "application/json")
+                .result_json(HETZNER_JSON_ZONE_RECORDS_GET_RESULT),
+                FetchUrlCall("POST", 200)
+                .expect_header("accept", "application/json")
+                .expect_header("auth-api-token", "foo")
+                .expect_url("https://dns.hetzner.com/api/v1/records")
+                .expect_json_value_absent(["id"])
+                .expect_json_value(["type"], "CAA")
+                .expect_json_value(["ttl"], 3600)
+                .expect_json_value(["zone_id"], "42")
+                .expect_json_value(["name"], "☺")  # FIXME!
+                .expect_json_value(["value"], '128 issue "letsencrypt.org"')
+                .return_header("Content-Type", "application/json")
+                .result_json(
+                    {
+                        "record": {
+                            "id": "133",
+                            "type": "CAA",
+                            "name": "xn--74h",
+                            "value": '128 issue "letsencrypt.org"',
+                            "ttl": 3600,
+                            "zone_id": "42",
+                        },
+                    }
+                ),
+            ],
+        )
+
+        assert result["changed"] is True
+        assert result["zone_id"] == "42"
+
     def test_modify_check(self, mocker):
         result = self.run_module_success(
             mocker,
@@ -2126,6 +2182,117 @@ class TestHetznerDNSRecordNewJSON(BaseTestModule):
                     .expect_header("Authorization", "Bearer foo")
                     .expect_url("https://api.hetzner.cloud/v1/zones/42/rrsets")
                     .expect_json_value(["name"], "xn--74h")
+                    .expect_json_value(["type"], "CAA")
+                    .expect_json_value(["ttl"], 3600)
+                    .expect_json_value(
+                        ["records", 0, "value"], '128 issue "letsencrypt.org"'
+                    )
+                    .expect_json_value(["records", 0, "comment"], None)
+                    .expect_json_value_absent(["records", 1])
+                    .return_header("Content-Type", "application/json")
+                    .result_json(
+                        {
+                            "rrset": {
+                                "id": "xn--74h/CAA",
+                                "name": "xn--74h",
+                                "type": "CAA",
+                                "ttl": 3600,
+                                "labels": {},
+                                "protection": {
+                                    "change": False,
+                                },
+                                "records": [
+                                    {
+                                        "value": '128 issue "letsencrypt.org"',
+                                        "comment": "",
+                                    },
+                                ],
+                                "zone": 42,
+                            },
+                            "action": {
+                                "id": 1,
+                                "command": "create_rrset",
+                                "status": "running",
+                                "progress": 50,
+                                "started": "2016-01-30T23:55:00Z",
+                                "finished": None,
+                                "resources": [
+                                    {
+                                        "id": 42,
+                                        "type": "zone",
+                                    },
+                                ],
+                                "error": None,
+                            },
+                        }
+                    ),
+                    FetchUrlCall("GET", 200)
+                    .expect_header("accept", "application/json")
+                    .expect_header("Authorization", "Bearer foo")
+                    .expect_url("https://api.hetzner.cloud/v1/actions/1")
+                    .return_header("Content-Type", "application/json")
+                    .result_json(
+                        {
+                            "action": {
+                                "id": 1,
+                                "command": "create_rrset",
+                                "status": "success",
+                                "progress": 100,
+                                "started": "2016-01-30T23:55:00Z",
+                                "finished": "2026-01-30T23:55:00Z",
+                                "resources": [
+                                    {
+                                        "id": 42,
+                                        "type": "zone",
+                                    },
+                                ],
+                                "error": None,
+                            },
+                        }
+                    ),
+                ],
+            )
+
+        assert result["changed"] is True
+        assert result["zone_id"] == "42"
+
+    def test_change_add_one_idn_prefix_zone_id(self, mocker):
+        with patch("time.sleep", mock_sleep):
+            result = self.run_module_success(
+                mocker,
+                hetzner_dns_record,
+                {
+                    "hetzner_api_token": "foo",
+                    "state": "present",
+                    "zone_id": "42",
+                    "prefix": "☺",
+                    "type": "CAA",
+                    "ttl": 3600,
+                    "value": '128 issue "letsencrypt.org"',
+                    "_ansible_remote_tmp": "/tmp/tmp",
+                    "_ansible_keep_remote_files": True,
+                },
+                [
+                    FetchUrlCall("GET", 200)
+                    .expect_header("accept", "application/json")
+                    .expect_header("Authorization", "Bearer foo")
+                    .expect_url(
+                        "https://api.hetzner.cloud/v1/zones/42/rrsets",
+                        without_query=True,
+                    )
+                    .expect_query_values("name", "☺")  # FIXME!
+                    .expect_query_values("type", "CAA")
+                    .expect_query_values("page", "1")
+                    .expect_query_values("per_page", "100")
+                    .return_header("Content-Type", "application/json")
+                    .result_json(
+                        get_hetzner_new_json_records(name="xn--74h", record_type="CAA")
+                    ),
+                    FetchUrlCall("POST", 201)
+                    .expect_header("accept", "application/json")
+                    .expect_header("Authorization", "Bearer foo")
+                    .expect_url("https://api.hetzner.cloud/v1/zones/42/rrsets")
+                    .expect_json_value(["name"], "☺")  # FIXME!
                     .expect_json_value(["type"], "CAA")
                     .expect_json_value(["ttl"], 3600)
                     .expect_json_value(

--- a/tests/unit/plugins/modules/test_hetzner_dns_record.py
+++ b/tests/unit/plugins/modules/test_hetzner_dns_record.py
@@ -863,7 +863,7 @@ class TestHetznerDNSRecordJSON(BaseTestModule):
                 .expect_json_value(["type"], "CAA")
                 .expect_json_value(["ttl"], 3600)
                 .expect_json_value(["zone_id"], "42")
-                .expect_json_value(["name"], "☺")  # FIXME!
+                .expect_json_value(["name"], "xn--74h")
                 .expect_json_value(["value"], '128 issue "letsencrypt.org"')
                 .return_header("Content-Type", "application/json")
                 .result_json(
@@ -2280,7 +2280,7 @@ class TestHetznerDNSRecordNewJSON(BaseTestModule):
                         "https://api.hetzner.cloud/v1/zones/42/rrsets",
                         without_query=True,
                     )
-                    .expect_query_values("name", "☺")  # FIXME!
+                    .expect_query_values("name", "xn--74h")
                     .expect_query_values("type", "CAA")
                     .expect_query_values("page", "1")
                     .expect_query_values("per_page", "100")
@@ -2292,7 +2292,7 @@ class TestHetznerDNSRecordNewJSON(BaseTestModule):
                     .expect_header("accept", "application/json")
                     .expect_header("Authorization", "Bearer foo")
                     .expect_url("https://api.hetzner.cloud/v1/zones/42/rrsets")
-                    .expect_json_value(["name"], "☺")  # FIXME!
+                    .expect_json_value(["name"], "xn--74h")
                     .expect_json_value(["type"], "CAA")
                     .expect_json_value(["ttl"], 3600)
                     .expect_json_value(

--- a/tests/unit/plugins/modules/test_hosttech_dns_record.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record.py
@@ -1256,6 +1256,65 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
         assert result["changed"] is True
         assert result["zone_id"] == 42
 
+    def test_change_add_one_idn_prefix_zone_id(self, mocker):
+        result = self.run_module_success(
+            mocker,
+            hosttech_dns_record,
+            {
+                "hosttech_token": "foo",
+                "state": "present",
+                "zone_id": 42,
+                "prefix": "☺",
+                "type": "CAA",
+                "ttl": 3600,
+                "value": '128 issue "letsencrypt.org"',
+                "_ansible_remote_tmp": "/tmp/tmp",
+                "_ansible_keep_remote_files": True,
+            },
+            [
+                FetchUrlCall("GET", 200)
+                .expect_header("accept", "application/json")
+                .expect_header("authorization", "Bearer foo")
+                .expect_url(
+                    "https://api.ns1.hosttech.eu/api/user/v1/zones/42/records",
+                    without_query=True,
+                )
+                .expect_query_values("type", "CAA")
+                .return_header("Content-Type", "application/json")
+                .result_json(HOSTTECH_JSON_ZONE_RECORDS_GET_RESULT),
+                FetchUrlCall("POST", 201)
+                .expect_header("accept", "application/json")
+                .expect_header("authorization", "Bearer foo")
+                .expect_url("https://api.ns1.hosttech.eu/api/user/v1/zones/42/records")
+                .expect_json_value_absent(["id"])
+                .expect_json_value(["type"], "CAA")
+                .expect_json_value(["ttl"], 3600)
+                .expect_json_value(["comment"], "")
+                .expect_json_value(["name"], "☺")  # FIXME!
+                .expect_json_value(["flag"], "128")
+                .expect_json_value(["tag"], "issue")
+                .expect_json_value(["value"], "letsencrypt.org")
+                .return_header("Content-Type", "application/json")
+                .result_json(
+                    {
+                        "data": {
+                            "id": 133,
+                            "type": "CAA",
+                            "name": "xn--74h",
+                            "flag": "128",
+                            "tag": "issue",
+                            "value": "letsencrypt.org",
+                            "ttl": 3600,
+                            "comment": "",
+                        },
+                    }
+                ),
+            ],
+        )
+
+        assert result["changed"] is True
+        assert result["zone_id"] == 42
+
     def test_modify_check(self, mocker):
         result = self.run_module_success(
             mocker,

--- a/tests/unit/plugins/modules/test_hosttech_dns_record.py
+++ b/tests/unit/plugins/modules/test_hosttech_dns_record.py
@@ -1290,7 +1290,7 @@ class TestHosttechDNSRecordJSON(BaseTestModule):
                 .expect_json_value(["type"], "CAA")
                 .expect_json_value(["ttl"], 3600)
                 .expect_json_value(["comment"], "")
-                .expect_json_value(["name"], "☺")  # FIXME!
+                .expect_json_value(["name"], "xn--74h")
                 .expect_json_value(["flag"], "128")
                 .expect_json_value(["tag"], "issue")
                 .expect_json_value(["value"], "letsencrypt.org")


### PR DESCRIPTION
##### SUMMARY
This case got forogtten, so accidentally IDNs were sent to the API instead of punycode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various DNS modules
