### PR TITLE
WIP: Use new Secrets API

### DIFF
--- a/plugins/doc_fragments/_hetzner.py
+++ b/plugins/doc_fragments/_hetzner.py
@@ -41,9 +41,11 @@ options:
   hetzner_token:
     env:
       - name: HETZNER_DNS_TOKEN
+    secret: true
   hetzner_api_token:
     env:
       - name: HETZNER_API_TOKEN
+    secret: true
 """
 
     # NOTE: This document fragment adds additional information on records.

--- a/plugins/doc_fragments/_hosttech.py
+++ b/plugins/doc_fragments/_hosttech.py
@@ -51,10 +51,12 @@ options:
     env:
       - name: ANSIBLE_HOSTTECH_API_PASSWORD
         version_added: 2.5.0
+    secret: true
   hosttech_token:
     env:
       - name: ANSIBLE_HOSTTECH_DNS_TOKEN
         version_added: 2.5.0
+    secret: true
 """
 
     # NOTE: This document fragment adds additional information on records.

--- a/plugins/doc_fragments/_infomaniak.py
+++ b/plugins/doc_fragments/_infomaniak.py
@@ -30,6 +30,7 @@ options:
   infomaniak_token:
     env:
       - name: ANSIBLE_INFOMANIAK_DNS_TOKEN
+    secret: true
 """
 
     # NOTE: This document fragment adds additional information on records.

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,3 +1,6 @@
+plugins/inventory/hetzner_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/hosttech_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/infomaniak_dns_records.py validate-modules:invalid-documentation  # secret not supported
 plugins/module_utils/_argspec.py pep8:E704
 plugins/module_utils/_hetzner/api.py pep8:E704
 plugins/module_utils/_infomaniak/api.py pep8:E704

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,3 +1,6 @@
+plugins/inventory/hetzner_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/hosttech_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/infomaniak_dns_records.py validate-modules:invalid-documentation  # secret not supported
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_info.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_set.py no-assert  # The asserts are mainly needed for type inference

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,3 +1,6 @@
+plugins/inventory/hetzner_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/hosttech_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/infomaniak_dns_records.py validate-modules:invalid-documentation  # secret not supported
 plugins/module_utils/_module/record.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_info.py no-assert  # The asserts are mainly needed for type inference
 plugins/module_utils/_module/record_set.py no-assert  # The asserts are mainly needed for type inference

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,3 +1,6 @@
+plugins/inventory/hetzner_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/hosttech_dns_records.py validate-modules:invalid-documentation  # secret not supported
+plugins/inventory/infomaniak_dns_records.py validate-modules:invalid-documentation  # secret not supported
 plugins/lookup/lookup_as_dict.py validate-modules:bad-return-value-key  # no-default-alpn is OK
 plugins/modules/nameserver_record_info.py validate-modules:bad-return-value-key  # Bad return value 'values' is in the process of being renamed; no-default-alpn is OK
 plugins/modules/wait_for_txt.py validate-modules:bad-return-value-key  # Bad return value 'values' is in the process of being renamed


### PR DESCRIPTION
##### SUMMARY
The Secrets API is being introduced for ansible-core 2.22 and allows modules and plugins to mark secret values for redaction. As opposed to the rudimentary `no_log` handling up until ansible-core 2.21, this improves masking of secret values.

More infos:
* https://forum.ansible.com/t/46291
* https://github.com/ansible/ansible/pull/87457
* https://github.com/ansible/ansible-documentation/pull/3934

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various
